### PR TITLE
heroku/rollbar and stvp/rollbar had diverged, bring them closer

### DIFF
--- a/async_client.go
+++ b/async_client.go
@@ -2,7 +2,6 @@ package rollbar
 
 import (
 	"net/http"
-	"regexp"
 	"sync"
 )
 
@@ -26,16 +25,7 @@ func New(token, environment, codeVersion, serverHost, serverRoot string) Client 
 // NewAsync builds an asynchronous implementation of the Client interface
 func NewAsync(token, environment, codeVersion, serverHost, serverRoot string) *AsyncClient {
 	buffer := 1000
-	configuration := configuration{
-		token:         token,
-		environment:   environment,
-		endpoint:      "https://api.rollbar.com/api/1/item",
-		filterHeaders: regexp.MustCompile("Authorization"),
-		filterFields:  regexp.MustCompile("password|secret|token"),
-		codeVersion:   codeVersion,
-		serverHost:    serverHost,
-		serverRoot:    serverRoot,
-	}
+	configuration := createConfiguration(token, environment, codeVersion, serverHost, serverRoot)
 	client := &AsyncClient{
 		Buffer:        buffer,
 		configuration: configuration,
@@ -57,6 +47,10 @@ func (c *AsyncClient) SetToken(token string) {
 
 func (c *AsyncClient) SetEnvironment(environment string) {
 	c.configuration.environment = environment
+}
+
+func (c *AsyncClient) SetPlatform(platform string) {
+	c.configuration.platform = platform
 }
 
 func (c *AsyncClient) SetCodeVersion(codeVersion string) {
@@ -83,6 +77,10 @@ func (c *AsyncClient) Token() string {
 
 func (c *AsyncClient) Environment() string {
 	return c.configuration.environment
+}
+
+func (c *AsyncClient) Platform() string {
+	return c.configuration.platform
 }
 
 func (c *AsyncClient) CodeVersion() string {

--- a/async_client.go
+++ b/async_client.go
@@ -1,0 +1,208 @@
+package rollbar
+
+import (
+	"net/http"
+	"regexp"
+	"sync"
+)
+
+// AsyncClient is the default concrete implementation of the Client interface
+// which sends all data to Rollbar asynchronously.
+type AsyncClient struct {
+	// Maximum number of errors allowed in the sending queue before we start
+	// dropping new errors on the floor.
+	Buffer int
+
+	configuration configuration
+	bodyChannel   chan map[string]interface{}
+	waitGroup     sync.WaitGroup
+}
+
+// New returns the default implementation of a Client
+func New(token, environment, codeVersion, serverHost, serverRoot string) Client {
+	return NewAsync(token, environment, codeVersion, serverHost, serverRoot)
+}
+
+// NewAsync builds an asynchronous implementation of the Client interface
+func NewAsync(token, environment, codeVersion, serverHost, serverRoot string) *AsyncClient {
+	buffer := 1000
+	configuration := configuration{
+		token:         token,
+		environment:   environment,
+		endpoint:      "https://api.rollbar.com/api/1/item",
+		filterHeaders: regexp.MustCompile("Authorization"),
+		filterFields:  regexp.MustCompile("password|secret|token"),
+		codeVersion:   codeVersion,
+		serverHost:    serverHost,
+		serverRoot:    serverRoot,
+	}
+	client := &AsyncClient{
+		Buffer:        buffer,
+		configuration: configuration,
+		bodyChannel:   make(chan map[string]interface{}, buffer),
+	}
+
+	go func() {
+		for body := range client.bodyChannel {
+			client.post(body)
+			client.waitGroup.Done()
+		}
+	}()
+	return client
+}
+
+func (c *AsyncClient) SetToken(token string) {
+	c.configuration.token = token
+}
+
+func (c *AsyncClient) SetEnvironment(environment string) {
+	c.configuration.environment = environment
+}
+
+func (c *AsyncClient) SetCodeVersion(codeVersion string) {
+	c.configuration.codeVersion = codeVersion
+}
+
+func (c *AsyncClient) SetServerHost(serverHost string) {
+	c.configuration.serverHost = serverHost
+}
+
+func (c *AsyncClient) SetServerRoot(serverRoot string) {
+	c.configuration.serverRoot = serverRoot
+}
+
+func (c *AsyncClient) SetCustom(custom map[string]interface{}) {
+	c.configuration.custom = custom
+}
+
+// -- Getters
+
+func (c *AsyncClient) Token() string {
+	return c.configuration.token
+}
+
+func (c *AsyncClient) Environment() string {
+	return c.configuration.environment
+}
+
+func (c *AsyncClient) CodeVersion() string {
+	return c.configuration.codeVersion
+}
+
+func (c *AsyncClient) ServerHost() string {
+	return c.configuration.serverHost
+}
+
+func (c *AsyncClient) ServerRoot() string {
+	return c.configuration.serverRoot
+}
+
+func (c *AsyncClient) Custom() map[string]interface{} {
+	return c.configuration.custom
+}
+
+// -- Error reporting
+
+var noExtras map[string]interface{}
+
+func (c *AsyncClient) Error(level string, err error) {
+	c.ErrorWithExtras(level, err, noExtras)
+}
+
+func (c *AsyncClient) ErrorWithExtras(level string, err error, extras map[string]interface{}) {
+	c.ErrorWithStackSkipWithExtras(level, err, 1, extras)
+}
+
+func (c *AsyncClient) RequestError(level string, r *http.Request, err error) {
+	c.RequestErrorWithExtras(level, r, err, noExtras)
+}
+
+func (c *AsyncClient) RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{}) {
+	c.RequestErrorWithStackSkipWithExtras(level, r, err, 1, extras)
+}
+
+func (c *AsyncClient) ErrorWithStackSkip(level string, err error, skip int) {
+	c.ErrorWithStackSkipWithExtras(level, err, skip, noExtras)
+}
+
+func (c *AsyncClient) ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
+	body := c.buildBody(level, err.Error(), extras)
+	data := body["data"].(map[string]interface{})
+	errBody, fingerprint := errorBody(err, skip)
+	data["body"] = errBody
+	data["fingerprint"] = fingerprint
+
+	c.push(body)
+}
+
+func (c *AsyncClient) RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int) {
+	c.RequestErrorWithStackSkipWithExtras(level, r, err, skip, noExtras)
+}
+
+func (c *AsyncClient) RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
+	body := c.buildBody(level, err.Error(), extras)
+	data := body["data"].(map[string]interface{})
+
+	errBody, fingerprint := errorBody(err, skip)
+	data["body"] = errBody
+	data["fingerprint"] = fingerprint
+
+	data["request"] = c.errorRequest(r)
+
+	c.push(body)
+}
+
+// -- Message reporting
+
+func (c *AsyncClient) Message(level string, msg string) {
+	c.MessageWithExtras(level, msg, noExtras)
+}
+
+func (c *AsyncClient) MessageWithExtras(level string, msg string, extras map[string]interface{}) {
+	body := c.buildBody(level, msg, extras)
+	data := body["data"].(map[string]interface{})
+	data["body"] = messageBody(msg)
+
+	c.push(body)
+}
+
+// -- Misc.
+
+// wait will block until the queue of errors / messages is empty.
+func (c *AsyncClient) Wait() {
+	c.waitGroup.Wait()
+}
+
+// Close on the asynchronous Client is an alias to Wait
+func (c *AsyncClient) Close() error {
+	c.Wait()
+	return nil
+}
+
+// Build the main JSON structure that will be sent to Rollbar with the
+// appropriate metadata.
+func (c *AsyncClient) buildBody(level, title string, extras map[string]interface{}) map[string]interface{} {
+	return buildBody(c.configuration, level, title, extras)
+}
+
+// Extract error details from a Request to a format that Rollbar accepts.
+func (c *AsyncClient) errorRequest(r *http.Request) map[string]interface{} {
+	return errorRequest(c.configuration, r)
+}
+
+// -- POST handling
+
+// Queue the given JSON body to be POSTed to Rollbar.
+func (c *AsyncClient) push(body map[string]interface{}) {
+	if len(c.bodyChannel) < c.Buffer {
+		c.waitGroup.Add(1)
+		c.bodyChannel <- body
+	} else {
+		rollbarError("buffer full, dropping error on the floor")
+	}
+}
+
+// POST the given JSON body to Rollbar synchronously.
+func (c *AsyncClient) post(body map[string]interface{}) {
+	clientPost(c.configuration.token, c.configuration.endpoint, body)
+}

--- a/async_client.go
+++ b/async_client.go
@@ -149,7 +149,7 @@ func (c *AsyncClient) RequestErrorWithStackSkip(level string, r *http.Request, e
 func (c *AsyncClient) RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
 	body := c.buildBody(level, err.Error(), extras)
 	data := addErrorToBody(c.configuration, body, err, skip)
-	data["request"] = c.errorRequest(r)
+	data["request"] = c.requestDetails(r)
 	c.push(body)
 }
 
@@ -163,8 +163,19 @@ func (c *AsyncClient) MessageWithExtras(level string, msg string, extras map[str
 	body := c.buildBody(level, msg, extras)
 	data := body["data"].(map[string]interface{})
 	data["body"] = messageBody(msg)
-
 	c.push(body)
+}
+
+func (c *AsyncClient) RequestMessage(level string, r *http.Request, msg string) {
+	c.RequestMessageWithExtras(level, r, msg, noExtras)
+}
+
+func (c *AsyncClient) RequestMessageWithExtras(level string, r *http.Request, msg string, extras map[string]interface{}) {
+	body := c.buildBody(level, msg, extras)
+	data := body["data"].(map[string]interface{})
+	data["body"] = messageBody(msg)
+	data["request"] = c.requestDetails(r)
+	c.post(body)
 }
 
 // -- Misc.
@@ -187,8 +198,8 @@ func (c *AsyncClient) buildBody(level, title string, extras map[string]interface
 }
 
 // Extract error details from a Request to a format that Rollbar accepts.
-func (c *AsyncClient) errorRequest(r *http.Request) map[string]interface{} {
-	return errorRequest(c.configuration, r)
+func (c *AsyncClient) requestDetails(r *http.Request) map[string]interface{} {
+	return requestDetails(c.configuration, r)
 }
 
 // -- POST handling

--- a/async_client.go
+++ b/async_client.go
@@ -1,6 +1,7 @@
 package rollbar
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
 )
@@ -105,6 +106,10 @@ var noExtras map[string]interface{}
 
 func (c *AsyncClient) Error(level string, err error) {
 	c.ErrorWithExtras(level, err, noExtras)
+}
+
+func (c *AsyncClient) Errorf(level string, format string, args ...interface{}) {
+	c.ErrorWithStackSkipWithExtras(level, fmt.Errorf(format, args...), 1, noExtras)
 }
 
 func (c *AsyncClient) ErrorWithExtras(level string, err error, extras map[string]interface{}) {

--- a/async_client.go
+++ b/async_client.go
@@ -70,6 +70,10 @@ func (c *AsyncClient) SetCustom(custom map[string]interface{}) {
 	c.configuration.custom = custom
 }
 
+func (c *AsyncClient) SetFingerprint(fingerprint bool) {
+	c.configuration.fingerprint = fingerprint
+}
+
 // -- Getters
 
 func (c *AsyncClient) Token() string {
@@ -98,6 +102,10 @@ func (c *AsyncClient) ServerRoot() string {
 
 func (c *AsyncClient) Custom() map[string]interface{} {
 	return c.configuration.custom
+}
+
+func (c *AsyncClient) Fingerprint() bool {
+	return c.configuration.fingerprint
 }
 
 // -- Error reporting
@@ -130,11 +138,7 @@ func (c *AsyncClient) ErrorWithStackSkip(level string, err error, skip int) {
 
 func (c *AsyncClient) ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
 	body := c.buildBody(level, err.Error(), extras)
-	data := body["data"].(map[string]interface{})
-	errBody, fingerprint := errorBody(err, skip)
-	data["body"] = errBody
-	data["fingerprint"] = fingerprint
-
+	addErrorToBody(c.configuration, body, err, skip)
 	c.push(body)
 }
 
@@ -144,14 +148,8 @@ func (c *AsyncClient) RequestErrorWithStackSkip(level string, r *http.Request, e
 
 func (c *AsyncClient) RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
 	body := c.buildBody(level, err.Error(), extras)
-	data := body["data"].(map[string]interface{})
-
-	errBody, fingerprint := errorBody(err, skip)
-	data["body"] = errBody
-	data["fingerprint"] = fingerprint
-
+	data := addErrorToBody(c.configuration, body, err, skip)
 	data["request"] = c.errorRequest(r)
-
 	c.push(body)
 }
 

--- a/async_client.go
+++ b/async_client.go
@@ -206,6 +206,6 @@ func (c *AsyncClient) push(body map[string]interface{}) {
 }
 
 // POST the given JSON body to Rollbar synchronously.
-func (c *AsyncClient) post(body map[string]interface{}) {
-	clientPost(c.configuration.token, c.configuration.endpoint, body)
+func (c *AsyncClient) post(body map[string]interface{}) error {
+	return clientPost(c.configuration.token, c.configuration.endpoint, body)
 }

--- a/client.go
+++ b/client.go
@@ -101,6 +101,10 @@ type configuration struct {
 }
 
 func createConfiguration(token, environment, codeVersion, serverHost, serverRoot string) configuration {
+	hostname := serverHost
+	if hostname == "" {
+		hostname, _ = os.Hostname()
+	}
 	return configuration{
 		token:         token,
 		environment:   environment,
@@ -109,7 +113,7 @@ func createConfiguration(token, environment, codeVersion, serverHost, serverRoot
 		filterHeaders: regexp.MustCompile("Authorization"),
 		filterFields:  regexp.MustCompile("password|secret|token"),
 		codeVersion:   codeVersion,
-		serverHost:    serverHost,
+		serverHost:    hostname,
 		serverRoot:    serverRoot,
 	}
 }
@@ -124,11 +128,6 @@ func buildBody(configuration configuration, level, title string, extras map[stri
 		custom[k] = v
 	}
 
-	hostname := configuration.serverHost
-	if hostname == "" {
-		hostname, _ = os.Hostname()
-	}
-
 	data := map[string]interface{}{
 		"environment":  configuration.environment,
 		"title":        title,
@@ -138,7 +137,7 @@ func buildBody(configuration configuration, level, title string, extras map[stri
 		"language":     "go",
 		"code_version": configuration.codeVersion,
 		"server": map[string]interface{}{
-			"host": hostname,
+			"host": configuration.serverHost,
 			"root": configuration.serverRoot,
 		},
 		"notifier": map[string]interface{}{

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"runtime"
 	"time"
@@ -123,6 +124,11 @@ func buildBody(configuration configuration, level, title string, extras map[stri
 		custom[k] = v
 	}
 
+	hostname := configuration.serverHost
+	if hostname == "" {
+		hostname, _ = os.Hostname()
+	}
+
 	data := map[string]interface{}{
 		"environment":  configuration.environment,
 		"title":        title,
@@ -132,7 +138,7 @@ func buildBody(configuration configuration, level, title string, extras map[stri
 		"language":     "go",
 		"code_version": configuration.codeVersion,
 		"server": map[string]interface{}{
-			"host": configuration.serverHost,
+			"host": hostname,
 			"root": configuration.serverRoot,
 		},
 		"notifier": map[string]interface{}{

--- a/client.go
+++ b/client.go
@@ -175,7 +175,7 @@ func errorRequest(configuration configuration, r *http.Request) map[string]inter
 // filterParams filters sensitive information like passwords from being sent to
 // Rollbar.
 func filterParams(pattern *regexp.Regexp, values map[string][]string) map[string][]string {
-	for key, _ := range values {
+	for key := range values {
 		if pattern.Match([]byte(key)) {
 			values[key] = []string{FILTERED}
 		}

--- a/client.go
+++ b/client.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"regexp"
 	"runtime"
-	"sync"
 	"time"
 )
 
@@ -30,18 +29,18 @@ type Client interface {
 	SetCustom(custom map[string]interface{})
 
 	// Rollbar access token.
-	GetToken() string
+	Token() string
 	// All errors and messages will be submitted under this environment.
-	GetEnvironment() string
+	Environment() string
 	// String describing the running code version on the server
-	GetCodeVersion() string
+	CodeVersion() string
 	// host: The server hostname. Will be indexed.
-	GetServerHost() string
+	ServerHost() string
 	// root: Path to the application code root, not including the final slash.
 	// Used to collapse non-project code when displaying tracebacks.
-	GetServerRoot() string
+	ServerRoot() string
 	// custom: Any arbitrary metadata you want to send.
-	GetCustom() map[string]interface{}
+	Custom() map[string]interface{}
 
 	// Error sends an error to Rollbar with the given severity level.
 	Error(level string, err error)
@@ -79,216 +78,39 @@ type Client interface {
 	MessageWithExtras(level string, msg string, extras map[string]interface{})
 }
 
-// AsyncClient is the default concrete implementation of the Client interface
-// which sends all data to Rollbar asynchronously.
-type AsyncClient struct {
-	// Rollbar access token. If this is blank, no errors will be reported to
-	// Rollbar.
-	Token string
-	// All errors and messages will be submitted under this environment.
-	Environment string
-	// API endpoint for Rollbar.
-	Endpoint string
-	// Maximum number of errors allowed in the sending queue before we start
-	// dropping new errors on the floor.
-	Buffer int
-	// Filter HTTP Headers parameters from being sent to Rollbar.
-	FilterHeaders *regexp.Regexp
-	// Filter GET and POST parameters from being sent to Rollbar.
-	FilterFields *regexp.Regexp
-	// String describing the running code version on the server
-	CodeVersion string
-	// host: The server hostname. Will be indexed.
-	ServerHost string
-	// root: Path to the application code root, not including the final slash.
-	// Used to collapse non-project code when displaying tracebacks.
-	ServerRoot string
-	// custom: Any arbitrary metadata you want to send.
-	Custom map[string]interface{}
-	// Queue of messages to be sent.
-	bodyChannel chan map[string]interface{}
-	waitGroup   sync.WaitGroup
-}
-
-// New returns the default implementation of a Client
-func New(token, environment, codeVersion, serverHost, serverRoot string) Client {
-	return NewAsync(token, environment, codeVersion, serverHost, serverRoot)
-}
-
-// NewAsync builds an asynchronous implementation of the Client interface
-func NewAsync(token, environment, codeVersion, serverHost, serverRoot string) *AsyncClient {
-	buffer := 1000
-	client := &AsyncClient{
-		Token:         token,
-		Environment:   environment,
-		Endpoint:      "https://api.rollbar.com/api/1/item/",
-		Buffer:        1000,
-		FilterHeaders: regexp.MustCompile("Authorization"),
-		FilterFields:  regexp.MustCompile("password|secret|token"),
-		CodeVersion:   codeVersion,
-		ServerHost:    serverHost,
-		ServerRoot:    serverRoot,
-		bodyChannel:   make(chan map[string]interface{}, buffer),
-	}
-
-	go func() {
-		for body := range client.bodyChannel {
-			client.post(body)
-			client.waitGroup.Done()
-		}
-	}()
-	return client
-}
-
-func (c *AsyncClient) SetToken(token string) {
-	c.Token = token
-}
-
-func (c *AsyncClient) SetEnvironment(environment string) {
-	c.Environment = environment
-}
-
-func (c *AsyncClient) SetCodeVersion(codeVersion string) {
-	c.CodeVersion = codeVersion
-}
-
-func (c *AsyncClient) SetServerHost(serverHost string) {
-	c.ServerHost = serverHost
-}
-
-func (c *AsyncClient) SetServerRoot(serverRoot string) {
-	c.ServerRoot = serverRoot
-}
-
-func (c *AsyncClient) SetCustom(custom map[string]interface{}) {
-	c.Custom = custom
-}
-
-// -- Getters
-
-func (c *AsyncClient) GetToken() string {
-	return c.Token
-}
-
-func (c *AsyncClient) GetEnvironment() string {
-	return c.Environment
-}
-
-func (c *AsyncClient) GetCodeVersion() string {
-	return c.CodeVersion
-}
-
-func (c *AsyncClient) GetServerHost() string {
-	return c.ServerHost
-}
-
-func (c *AsyncClient) GetServerRoot() string {
-	return c.ServerRoot
-}
-
-func (c *AsyncClient) GetCustom() map[string]interface{} {
-	return c.Custom
-}
-
-// -- Error reporting
-
-var noExtras map[string]interface{}
-
-func (c *AsyncClient) Error(level string, err error) {
-	c.ErrorWithExtras(level, err, noExtras)
-}
-
-func (c *AsyncClient) ErrorWithExtras(level string, err error, extras map[string]interface{}) {
-	c.ErrorWithStackSkipWithExtras(level, err, 1, extras)
-}
-
-func (c *AsyncClient) RequestError(level string, r *http.Request, err error) {
-	c.RequestErrorWithExtras(level, r, err, noExtras)
-}
-
-func (c *AsyncClient) RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{}) {
-	c.RequestErrorWithStackSkipWithExtras(level, r, err, 1, extras)
-}
-
-func (c *AsyncClient) ErrorWithStackSkip(level string, err error, skip int) {
-	c.ErrorWithStackSkipWithExtras(level, err, skip, noExtras)
-}
-
-func (c *AsyncClient) ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
-	body := c.buildBody(level, err.Error(), extras)
-	data := body["data"].(map[string]interface{})
-	errBody, fingerprint := errorBody(err, skip)
-	data["body"] = errBody
-	data["fingerprint"] = fingerprint
-
-	c.push(body)
-}
-
-func (c *AsyncClient) RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int) {
-	c.RequestErrorWithStackSkipWithExtras(level, r, err, skip, noExtras)
-}
-
-func (c *AsyncClient) RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
-	body := c.buildBody(level, err.Error(), extras)
-	data := body["data"].(map[string]interface{})
-
-	errBody, fingerprint := errorBody(err, skip)
-	data["body"] = errBody
-	data["fingerprint"] = fingerprint
-
-	data["request"] = c.errorRequest(r)
-
-	c.push(body)
-}
-
-// -- Message reporting
-
-func (c *AsyncClient) Message(level string, msg string) {
-	c.MessageWithExtras(level, msg, noExtras)
-}
-
-func (c *AsyncClient) MessageWithExtras(level string, msg string, extras map[string]interface{}) {
-	body := c.buildBody(level, msg, extras)
-	data := body["data"].(map[string]interface{})
-	data["body"] = messageBody(msg)
-
-	c.push(body)
-}
-
-// -- Misc.
-
-// wait will block until the queue of errors / messages is empty.
-func (c *AsyncClient) Wait() {
-	c.waitGroup.Wait()
-}
-
-// Close on the asynchronous Client is an alias to Wait
-func (c *AsyncClient) Close() error {
-	c.Wait()
-	return nil
+type configuration struct {
+	token         string
+	environment   string
+	codeVersion   string
+	serverHost    string
+	serverRoot    string
+	endpoint      string
+	custom        map[string]interface{}
+	filterHeaders *regexp.Regexp
+	filterFields  *regexp.Regexp
 }
 
 // Build the main JSON structure that will be sent to Rollbar with the
 // appropriate metadata.
-func (c *AsyncClient) buildBody(level, title string, extras map[string]interface{}) map[string]interface{} {
+func buildBody(configuration configuration, level, title string, extras map[string]interface{}) map[string]interface{} {
 	timestamp := time.Now().Unix()
 
-	custom := c.Custom
+	custom := configuration.custom
 	for k, v := range extras {
 		custom[k] = v
 	}
 
 	data := map[string]interface{}{
-		"environment":  c.Environment,
+		"environment":  configuration.environment,
 		"title":        title,
 		"level":        level,
 		"timestamp":    timestamp,
 		"platform":     runtime.GOOS,
 		"language":     "go",
-		"code_version": c.CodeVersion,
+		"code_version": configuration.codeVersion,
 		"server": map[string]interface{}{
-			"host": c.ServerHost,
-			"root": c.ServerRoot,
+			"host": configuration.serverHost,
+			"root": configuration.serverRoot,
 		},
 		"notifier": map[string]interface{}{
 			"name":    NAME,
@@ -298,26 +120,26 @@ func (c *AsyncClient) buildBody(level, title string, extras map[string]interface
 	}
 
 	return map[string]interface{}{
-		"access_token": c.Token,
+		"access_token": configuration.token,
 		"data":         data,
 	}
 }
 
 // Extract error details from a Request to a format that Rollbar accepts.
-func (c *AsyncClient) errorRequest(r *http.Request) map[string]interface{} {
-	cleanQuery := filterParams(c.FilterFields, r.URL.Query())
+func errorRequest(configuration configuration, r *http.Request) map[string]interface{} {
+	cleanQuery := filterParams(configuration.filterFields, r.URL.Query())
 
 	return map[string]interface{}{
 		"url":     r.URL.String(),
 		"method":  r.Method,
-		"headers": flattenValues(filterParams(c.FilterHeaders, r.Header)),
+		"headers": flattenValues(filterParams(configuration.filterHeaders, r.Header)),
 
 		// GET params
 		"query_string": url.Values(cleanQuery).Encode(),
 		"GET":          flattenValues(cleanQuery),
 
 		// POST / PUT params
-		"POST": flattenValues(filterParams(c.FilterFields, r.Form)),
+		"POST": flattenValues(filterParams(configuration.filterFields, r.Form)),
 	}
 }
 
@@ -349,19 +171,8 @@ func flattenValues(values map[string][]string) map[string]interface{} {
 
 // -- POST handling
 
-// Queue the given JSON body to be POSTed to Rollbar.
-func (c *AsyncClient) push(body map[string]interface{}) {
-	if len(c.bodyChannel) < c.Buffer {
-		c.waitGroup.Add(1)
-		c.bodyChannel <- body
-	} else {
-		rollbarError("buffer full, dropping error on the floor")
-	}
-}
-
-// POST the given JSON body to Rollbar synchronously.
-func (c *AsyncClient) post(body map[string]interface{}) {
-	if len(c.Token) == 0 {
+func clientPost(token, endpoint string, body map[string]interface{}) {
+	if len(token) == 0 {
 		rollbarError("empty token")
 		return
 	}
@@ -372,7 +183,7 @@ func (c *AsyncClient) post(body map[string]interface{}) {
 		return
 	}
 
-	resp, err := http.Post(c.Endpoint, "application/json", bytes.NewReader(jsonBody))
+	resp, err := http.Post(endpoint, "application/json", bytes.NewReader(jsonBody))
 	if err != nil {
 		rollbarError("POST failed: %s", err.Error())
 	} else if resp.StatusCode != 200 {

--- a/client.go
+++ b/client.go
@@ -50,6 +50,8 @@ type Client interface {
 
 	// Error sends an error to Rollbar with the given severity level.
 	Error(level string, err error)
+	// Errorf sends an error to Rollbar with the given format string and arguments.
+	Errorf(level string, format string, args ...interface{})
 	// ErrorWithExtras sends an error to Rollbar with the given severity
 	// level with extra custom data.
 	ErrorWithExtras(level string, err error, extras map[string]interface{})

--- a/client.go
+++ b/client.go
@@ -167,7 +167,8 @@ func errorRequest(configuration configuration, r *http.Request) map[string]inter
 		"GET":          flattenValues(cleanQuery),
 
 		// POST / PUT params
-		"POST": flattenValues(filterParams(configuration.filterFields, r.Form)),
+		"POST":    flattenValues(filterParams(configuration.filterFields, r.Form)),
+		"user_ip": r.RemoteAddr,
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,14 @@
+package rollbar
+
+import (
+	"fmt"
+)
+
+// ErrHTTPError is an HTTP error status code as defined by
+// http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+type ErrHTTPError int
+
+// Error implements the error interface.
+func (e ErrHTTPError) Error() string {
+	return fmt.Sprintf("rollbar: service returned status: %d", e)
+}

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+  "os"
+	"encoding/json"
+	"fmt"
+	"github.com/rollbar/rollbar-go"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func helloJson(w http.ResponseWriter, r *http.Request) {
+	var u map[string]interface{}
+	err := json.NewDecoder(r.Body).Decode(&u)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+	}
+	fmt.Println("path", r.URL.Path)
+	fmt.Println("scheme", r.URL.Scheme)
+	for k, v := range u {
+		fmt.Println("key:", k)
+		fmt.Println("val:", v)
+	}
+	rollbar.RequestMessage(rollbar.INFO, r, "Example message json")
+	fmt.Fprintf(w, "Hello world!")
+}
+
+func helloForm(w http.ResponseWriter, r *http.Request) {
+	r.ParseForm()
+	fmt.Println("path", r.URL.Path)
+	fmt.Println("scheme", r.URL.Scheme)
+	for k, v := range r.Form {
+		fmt.Println("key:", k)
+		fmt.Println("val:", strings.Join(v, " "))
+	}
+	rollbar.RequestMessage(rollbar.INFO, r, "Example message form")
+	fmt.Fprintf(w, "Hello world!")
+}
+
+func main() {
+  var token = os.Getenv("TOKEN")
+	rollbar.SetToken(token)
+	rollbar.SetEnvironment("test")
+	http.HandleFunc("/json", helloJson)
+	http.HandleFunc("/form", helloForm)
+	err := http.ListenAndServe(":9090", nil)
+	if err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
+	rollbar.Wait()
+}

--- a/rollbar.go
+++ b/rollbar.go
@@ -63,34 +63,34 @@ func SetCustom(custom map[string]interface{}) {
 // -- Getters
 
 // Rollbar access token.
-func GetToken() string {
-	return std.GetToken()
+func Token() string {
+	return std.Token()
 }
 
 // All errors and messages will be submitted under this environment.
-func GetEnvironment() string {
-	return std.GetEnvironment()
+func Environment() string {
+	return std.Environment()
 }
 
 // String describing the running code version on the server
-func GetCodeVersion() string {
-	return std.GetCodeVersion()
+func CodeVersion() string {
+	return std.CodeVersion()
 }
 
 // host: The server hostname. Will be indexed.
-func GetServerHost() string {
-	return std.GetServerHost()
+func ServerHost() string {
+	return std.ServerHost()
 }
 
 // root: Path to the application code root, not including the final slash.
 // Used to collapse non-project code when displaying tracebacks.
-func GetServerRoot() string {
-	return std.GetServerRoot()
+func ServerRoot() string {
+	return std.ServerRoot()
 }
 
 // custom: Any arbitrary metadata you want to send.
-func GetCustom() map[string]interface{} {
-	return std.GetCustom()
+func Custom() map[string]interface{} {
+	return std.Custom()
 }
 
 // -- Error reporting

--- a/rollbar.go
+++ b/rollbar.go
@@ -159,6 +159,19 @@ func MessageWithExtras(level string, msg string, extras map[string]interface{}) 
 	std.MessageWithExtras(level, msg, extras)
 }
 
+// RequestMessage asynchronously sends a message to Rollbar with the given
+// severity level and request-specific information.
+func RequestMessage(level string, r *http.Request, msg string) {
+	std.RequestMessage(level, r, msg)
+}
+
+// RequestMessageWithExtras asynchronously sends a message to Rollbar with the given severity
+// level with extra custom data in addition to extra request-specific information.
+// Rollbar request is asynchronous.
+func RequestMessageWithExtras(level string, r *http.Request, msg string, extras map[string]interface{}) {
+	std.RequestMessageWithExtras(level, r, msg, extras)
+}
+
 // Wait will block until the queue of errors / messages is empty.
 func Wait() {
 	std.Wait()

--- a/rollbar.go
+++ b/rollbar.go
@@ -178,14 +178,16 @@ type CauseStacker interface {
 // Build an error inner-body for the given error. If skip is provided, that
 // number of stack trace frames will be skipped. If the error has a Cause
 // method, the causes will be traversed until nil.
-func errorBody(err error, skip int) (map[string]interface{}, string) {
+func errorBody(configuration configuration, err error, skip int) (map[string]interface{}, string) {
 	var parent error
 	traceChain := []map[string]interface{}{}
 	fingerprint := ""
 	for {
 		stack := getOrBuildStack(err, parent, skip)
 		traceChain = append(traceChain, buildTrace(err, stack))
-		fingerprint = fingerprint + stack.Fingerprint()
+		if configuration.fingerprint {
+			fingerprint = fingerprint + stack.Fingerprint()
+		}
 		parent = err
 		err = getCause(err)
 		if err == nil {

--- a/rollbar.go
+++ b/rollbar.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	NAME    = "heroku/rollbar"
-	VERSION = "0.4.1"
+	NAME    = "rollbar/rollbar-go"
+	VERSION = "0.6.0"
 
 	// Severity levels
 	CRIT  = "critical"

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -48,10 +48,10 @@ func TestErrorClass(t *testing.T) {
 func TestEverything(t *testing.T) {
 	SetToken(os.Getenv("TOKEN"))
 	SetEnvironment("test")
-	if GetToken() != os.Getenv("TOKEN") {
+	if Token() != os.Getenv("TOKEN") {
 		t.Error("Token should be as set")
 	}
-	if GetEnvironment() != "test" {
+	if Environment() != "test" {
 		t.Error("Token should be as set")
 	}
 
@@ -89,7 +89,7 @@ func TestBuildBody(t *testing.T) {
 		"EXTRA_CUSTOM_KEY":      "EXTRA_CUSTOM_VALUE",
 		"OVERRIDDEN_CUSTOM_KEY": "EXTRA",
 	}
-	body := std.(*AsyncClient).buildBody(ERR, "test error", extraCustom)
+	body := interface{}(std).(*AsyncClient).buildBody(ERR, "test error", extraCustom)
 
 	if body["data"] == nil {
 		t.Error("body should have data")
@@ -136,7 +136,7 @@ func TestFilterParams(t *testing.T) {
 		"access_token": []string{"one"},
 	}
 
-	clean := filterParams(std.FilterFields, values)
+	clean := filterParams(std.configuration.filterFields, values)
 	if clean["password"][0] != FILTERED {
 		t.Error("should filter password parameter")
 	}

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -114,7 +114,7 @@ func TestErrorRequest(t *testing.T) {
 	r, _ := http.NewRequest("GET", "http://foo.com/somethere?param1=true", nil)
 	r.RemoteAddr = "1.1.1.1:123"
 
-	object := std.errorRequest(r)
+	object := std.requestDetails(r)
 
 	if object["url"] != "http://foo.com/somethere?param1=true" {
 		t.Errorf("wrong url, got %v", object["url"])

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -228,7 +228,7 @@ func TestGetOrBuildStackOfCauseStackerWithParent(t *testing.T) {
 
 func TestErrorBodyWithoutChain(t *testing.T) {
 	err := fmt.Errorf("ERR")
-	errorBody, fingerprint := errorBody(err, 0)
+	errorBody, fingerprint := errorBody(configuration{fingerprint: true}, err, 0)
 	if nil != errorBody["trace"] {
 		t.Error("should not have trace element")
 	}
@@ -251,7 +251,7 @@ func TestErrorBodyWithChain(t *testing.T) {
 	cause := fmt.Errorf("cause")
 	effect := cs{fmt.Errorf("effect1"), cause, BuildStack(0)}
 	effect2 := cs{fmt.Errorf("effect2"), effect, BuildStack(0)}
-	errorBody, fingerprint := errorBody(effect2, 0)
+	errorBody, fingerprint := errorBody(configuration{fingerprint: true}, effect2, 0)
 	if nil != errorBody["trace"] {
 		t.Error("should not have trace element")
 	}

--- a/stack.go
+++ b/stack.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	knownFilePathPatterns []string = []string{
+	knownFilePathPatterns = []string{
 		"github.com/",
 		"code.google.com/",
 		"bitbucket.org/",

--- a/stack_test.go
+++ b/stack_test.go
@@ -6,10 +6,10 @@ import (
 
 func TestBuildStack(t *testing.T) {
 	frame := BuildStack(1)[0]
-	if frame.Filename != "github.com/heroku/rollbar/stack_test.go" {
+	if frame.Filename != "github.com/rollbar/rollbar-go/stack_test.go" {
 		t.Errorf("got: %s", frame.Filename)
 	}
-	if frame.Method != "rollbar.TestBuildStack" {
+	if frame.Method != "rollbar-go.TestBuildStack" {
 		t.Errorf("got: %s", frame.Method)
 	}
 	if frame.Line != 8 {

--- a/sync_client.go
+++ b/sync_client.go
@@ -1,0 +1,211 @@
+package rollbar
+
+import (
+	"net/http"
+	"net/url"
+	"regexp"
+	"runtime"
+	"time"
+)
+
+// SyncClient is an alternate concrete implementation of the Client interface
+// which sends all data to Rollbar synchronously.
+type SyncClient struct {
+	configuration configuration
+}
+
+// NewSync builds a synchronous implementation of the Client interface
+func NewSync(token, environment, codeVersion, serverHost, serverRoot string) *SyncClient {
+	configuration := configuration{
+		token:         token,
+		environment:   environment,
+		endpoint:      "https://api.rollbar.com/api/1/item",
+		filterHeaders: regexp.MustCompile("Authorization"),
+		filterFields:  regexp.MustCompile("password|secret|token"),
+		codeVersion:   codeVersion,
+		serverHost:    serverHost,
+		serverRoot:    serverRoot,
+	}
+	client := &SyncClient{
+		configuration: configuration,
+	}
+	return client
+}
+
+func (c *SyncClient) SetToken(token string) {
+	c.configuration.token = token
+}
+
+func (c *SyncClient) SetEnvironment(environment string) {
+	c.configuration.environment = environment
+}
+
+func (c *SyncClient) SetCodeVersion(codeVersion string) {
+	c.configuration.codeVersion = codeVersion
+}
+
+func (c *SyncClient) SetServerHost(serverHost string) {
+	c.configuration.serverHost = serverHost
+}
+
+func (c *SyncClient) SetServerRoot(serverRoot string) {
+	c.configuration.serverRoot = serverRoot
+}
+
+func (c *SyncClient) SetCustom(custom map[string]interface{}) {
+	c.configuration.custom = custom
+}
+
+func (c *SyncClient) Token() string {
+	return c.configuration.token
+}
+
+func (c *SyncClient) Environment() string {
+	return c.configuration.environment
+}
+
+func (c *SyncClient) CodeVersion() string {
+	return c.configuration.codeVersion
+}
+
+func (c *SyncClient) ServerHost() string {
+	return c.configuration.serverHost
+}
+
+func (c *SyncClient) ServerRoot() string {
+	return c.configuration.serverRoot
+}
+
+func (c *SyncClient) Custom() map[string]interface{} {
+	return c.configuration.custom
+}
+
+// -- Error reporting
+
+func (c *SyncClient) Error(level string, err error) {
+	c.ErrorWithExtras(level, err, noExtras)
+}
+
+func (c *SyncClient) ErrorWithExtras(level string, err error, extras map[string]interface{}) {
+	c.ErrorWithStackSkipWithExtras(level, err, 1, extras)
+}
+
+func (c *SyncClient) RequestError(level string, r *http.Request, err error) {
+	c.RequestErrorWithExtras(level, r, err, noExtras)
+}
+
+func (c *SyncClient) RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{}) {
+	c.RequestErrorWithStackSkipWithExtras(level, r, err, 1, extras)
+}
+
+func (c *SyncClient) ErrorWithStackSkip(level string, err error, skip int) {
+	c.ErrorWithStackSkipWithExtras(level, err, skip, noExtras)
+}
+
+func (c *SyncClient) ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
+	body := c.buildBody(level, err.Error(), extras)
+	data := body["data"].(map[string]interface{})
+	errBody, fingerprint := errorBody(err, skip)
+	data["body"] = errBody
+	data["fingerprint"] = fingerprint
+
+	c.post(body)
+}
+
+func (c *SyncClient) RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int) {
+	c.RequestErrorWithStackSkipWithExtras(level, r, err, skip, noExtras)
+}
+
+func (c *SyncClient) RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
+	body := c.buildBody(level, err.Error(), extras)
+	data := body["data"].(map[string]interface{})
+
+	errBody, fingerprint := errorBody(err, skip)
+	data["body"] = errBody
+	data["fingerprint"] = fingerprint
+
+	data["request"] = c.errorRequest(r)
+
+	c.post(body)
+}
+
+// -- Message reporting
+
+func (c *SyncClient) Message(level string, msg string) {
+	c.MessageWithExtras(level, msg, noExtras)
+}
+
+func (c *SyncClient) MessageWithExtras(level string, msg string, extras map[string]interface{}) {
+	body := c.buildBody(level, msg, extras)
+	data := body["data"].(map[string]interface{})
+	data["body"] = messageBody(msg)
+
+	c.post(body)
+}
+
+// -- Misc.
+
+// Close on the synchronous Client does nothing
+func (c *SyncClient) Close() error {
+	return nil
+}
+
+// Build the main JSON structure that will be sent to Rollbar with the
+// appropriate metadata.
+func (c *SyncClient) buildBody(level, title string, extras map[string]interface{}) map[string]interface{} {
+	timestamp := time.Now().Unix()
+
+	custom := c.configuration.custom
+	for k, v := range extras {
+		custom[k] = v
+	}
+
+	data := map[string]interface{}{
+		"environment":  c.configuration.environment,
+		"title":        title,
+		"level":        level,
+		"timestamp":    timestamp,
+		"platform":     runtime.GOOS,
+		"language":     "go",
+		"code_version": c.configuration.codeVersion,
+		"server": map[string]interface{}{
+			"host": c.configuration.serverHost,
+			"root": c.configuration.serverRoot,
+		},
+		"notifier": map[string]interface{}{
+			"name":    NAME,
+			"version": VERSION,
+		},
+		"custom": custom,
+	}
+
+	return map[string]interface{}{
+		"access_token": c.configuration.token,
+		"data":         data,
+	}
+}
+
+// Extract error details from a Request to a format that Rollbar accepts.
+func (c *SyncClient) errorRequest(r *http.Request) map[string]interface{} {
+	cleanQuery := filterParams(c.configuration.filterFields, r.URL.Query())
+
+	return map[string]interface{}{
+		"url":     r.URL.String(),
+		"method":  r.Method,
+		"headers": flattenValues(filterParams(c.configuration.filterHeaders, r.Header)),
+
+		// GET params
+		"query_string": url.Values(cleanQuery).Encode(),
+		"GET":          flattenValues(cleanQuery),
+
+		// POST / PUT params
+		"POST": flattenValues(filterParams(c.configuration.filterFields, r.Form)),
+	}
+}
+
+// -- POST handling
+
+// POST the given JSON body to Rollbar synchronously.
+func (c *SyncClient) post(body map[string]interface{}) {
+	clientPost(c.configuration.token, c.configuration.endpoint, body)
+}

--- a/sync_client.go
+++ b/sync_client.go
@@ -1,6 +1,7 @@
 package rollbar
 
 import (
+	"fmt"
 	"net/http"
 )
 
@@ -79,6 +80,10 @@ func (c *SyncClient) Custom() map[string]interface{} {
 
 func (c *SyncClient) Error(level string, err error) {
 	c.ErrorWithExtras(level, err, noExtras)
+}
+
+func (c *SyncClient) Errorf(level string, format string, args ...interface{}) {
+	c.ErrorWithStackSkipWithExtras(level, fmt.Errorf(format, args...), 1, noExtras)
 }
 
 func (c *SyncClient) ErrorWithExtras(level string, err error, extras map[string]interface{}) {

--- a/sync_client.go
+++ b/sync_client.go
@@ -104,11 +104,7 @@ func (c *SyncClient) ErrorWithStackSkip(level string, err error, skip int) {
 
 func (c *SyncClient) ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
 	body := c.buildBody(level, err.Error(), extras)
-	data := body["data"].(map[string]interface{})
-	errBody, fingerprint := errorBody(err, skip)
-	data["body"] = errBody
-	data["fingerprint"] = fingerprint
-
+	addErrorToBody(c.configuration, body, err, skip)
 	c.post(body)
 }
 
@@ -118,14 +114,8 @@ func (c *SyncClient) RequestErrorWithStackSkip(level string, r *http.Request, er
 
 func (c *SyncClient) RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
 	body := c.buildBody(level, err.Error(), extras)
-	data := body["data"].(map[string]interface{})
-
-	errBody, fingerprint := errorBody(err, skip)
-	data["body"] = errBody
-	data["fingerprint"] = fingerprint
-
+	data := addErrorToBody(c.configuration, body, err, skip)
 	data["request"] = c.errorRequest(r)
-
 	c.post(body)
 }
 

--- a/sync_client.go
+++ b/sync_client.go
@@ -115,7 +115,7 @@ func (c *SyncClient) RequestErrorWithStackSkip(level string, r *http.Request, er
 func (c *SyncClient) RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
 	body := c.buildBody(level, err.Error(), extras)
 	data := addErrorToBody(c.configuration, body, err, skip)
-	data["request"] = c.errorRequest(r)
+	data["request"] = c.requestDetails(r)
 	c.post(body)
 }
 
@@ -129,7 +129,18 @@ func (c *SyncClient) MessageWithExtras(level string, msg string, extras map[stri
 	body := c.buildBody(level, msg, extras)
 	data := body["data"].(map[string]interface{})
 	data["body"] = messageBody(msg)
+	c.post(body)
+}
 
+func (c *SyncClient) RequestMessage(level string, r *http.Request, msg string) {
+	c.RequestMessageWithExtras(level, r, msg, noExtras)
+}
+
+func (c *SyncClient) RequestMessageWithExtras(level string, r *http.Request, msg string, extras map[string]interface{}) {
+	body := c.buildBody(level, msg, extras)
+	data := body["data"].(map[string]interface{})
+	data["body"] = messageBody(msg)
+	data["request"] = c.requestDetails(r)
 	c.post(body)
 }
 
@@ -147,8 +158,8 @@ func (c *SyncClient) buildBody(level, title string, extras map[string]interface{
 }
 
 // Extract error details from a Request to a format that Rollbar accepts.
-func (c *SyncClient) errorRequest(r *http.Request) map[string]interface{} {
-	return errorRequest(c.configuration, r)
+func (c *SyncClient) requestDetails(r *http.Request) map[string]interface{} {
+	return requestDetails(c.configuration, r)
 }
 
 // -- POST handling

--- a/sync_client.go
+++ b/sync_client.go
@@ -164,6 +164,6 @@ func (c *SyncClient) errorRequest(r *http.Request) map[string]interface{} {
 // -- POST handling
 
 // POST the given JSON body to Rollbar synchronously.
-func (c *SyncClient) post(body map[string]interface{}) {
-	clientPost(c.configuration.token, c.configuration.endpoint, body)
+func (c *SyncClient) post(body map[string]interface{}) error {
+	return clientPost(c.configuration.token, c.configuration.endpoint, body)
 }


### PR DESCRIPTION
stvp/rollbar had 55 commits that were not in the heroku/rollbar fork. This PR is intended to bring over the stuff that was added to stvp/rollbar into our notifier. Just doing a merge was a bit harder than essentially duplicating the work because the file structure had diverged too much.

I took the opportunity to also refactor some things related to how the internals of the client works, which allowed me to also create a synchronous client implementation.