### PR TITLE
Retry temporary http errors and dump items to stderr

### DIFF
--- a/async_transport.go
+++ b/async_transport.go
@@ -17,9 +17,21 @@ type AsyncTransport struct {
 	Logger ClientLogger
 	// Buffer is the size of the channel used for queueing asynchronous payloads for sending to
 	// Rollbar.
-	Buffer      int
-	bodyChannel chan map[string]interface{}
-	waitGroup   sync.WaitGroup
+	Buffer int
+	// RetryAttempts is how often to attempt to resend an item when a temporary network error occurs
+	// This defaults to DefaultRetryAttempts
+	// Set this value to 0 if you do not want retries to happen
+	RetryAttempts int
+	// PrintPayloadOnError is whether or not to output the payload to the set logger or to stderr
+	// if an error occurs during transport to the Rollbar API.
+	PrintPayloadOnError bool
+	bodyChannel         chan payload
+	waitGroup           sync.WaitGroup
+}
+
+type payload struct {
+	body        map[string]interface{}
+	retriesLeft int
 }
 
 // NewAsyncTransport builds an asynchronous transport which sends data to the Rollbar API at the
@@ -27,16 +39,30 @@ type AsyncTransport struct {
 // buffer argument.
 func NewAsyncTransport(token string, endpoint string, buffer int) *AsyncTransport {
 	transport := &AsyncTransport{
-		Token:       token,
-		Endpoint:    endpoint,
-		Buffer:      buffer,
-		bodyChannel: make(chan map[string]interface{}, buffer),
+		Token:               token,
+		Endpoint:            endpoint,
+		Buffer:              buffer,
+		RetryAttempts:       DefaultRetryAttempts,
+		PrintPayloadOnError: true,
+		bodyChannel:         make(chan payload, buffer),
 	}
 
 	go func() {
-		for body := range transport.bodyChannel {
-			transport.post(body)
-			transport.waitGroup.Done()
+		for p := range transport.bodyChannel {
+			err, canRetry := transport.post(p)
+			if err != nil {
+				if canRetry && p.retriesLeft > 0 {
+					p.retriesLeft -= 1
+					transport.bodyChannel <- p
+				} else {
+					if transport.PrintPayloadOnError {
+						writePayloadToStderr(transport.Logger, p.body)
+					}
+					transport.waitGroup.Done()
+				}
+			} else {
+				transport.waitGroup.Done()
+			}
 		}
 	}()
 	return transport
@@ -47,10 +73,17 @@ func NewAsyncTransport(token string, endpoint string, buffer int) *AsyncTranspor
 func (t *AsyncTransport) Send(body map[string]interface{}) error {
 	if len(t.bodyChannel) < t.Buffer {
 		t.waitGroup.Add(1)
-		t.bodyChannel <- body
+		p := payload{
+			body:        body,
+			retriesLeft: t.RetryAttempts,
+		}
+		t.bodyChannel <- p
 	} else {
 		err := ErrBufferFull{}
 		rollbarError(t.Logger, err.Error())
+		if t.PrintPayloadOnError {
+			writePayloadToStderr(t.Logger, body)
+		}
 		return err
 	}
 	return nil
@@ -91,6 +124,19 @@ func (t *AsyncTransport) SetLogger(logger ClientLogger) {
 	t.Logger = logger
 }
 
-func (t *AsyncTransport) post(body map[string]interface{}) error {
-	return clientPost(t.Token, t.Endpoint, body, t.Logger)
+// SetRetryAttempts is how often to attempt to resend an item when a temporary network error occurs
+// This defaults to DefaultRetryAttempts
+// Set this value to 0 if you do not want retries to happen
+func (t *AsyncTransport) SetRetryAttempts(retryAttempts int) {
+	t.RetryAttempts = retryAttempts
+}
+
+// SetPrintPayloadOnError is whether or not to output the payload to stderr if an error occurs during
+// transport to the Rollbar API.
+func (t *AsyncTransport) SetPrintPayloadOnError(printPayloadOnError bool) {
+	t.PrintPayloadOnError = printPayloadOnError
+}
+
+func (t *AsyncTransport) post(p payload) (error, bool) {
+	return clientPost(t.Token, t.Endpoint, p.body, t.Logger)
 }

--- a/client.go
+++ b/client.go
@@ -505,7 +505,7 @@ func clientPost(token, endpoint string, body map[string]interface{}, logger Clie
 	return nil, false
 }
 
-// isTemporary returns true if we should continue the error returned from http.Post to be temporary
+// isTemporary returns true if we should consider the error returned from http.Post to be temporary
 // in nature and possibly resolvable by simplying trying the request again.
 // https://github.com/grpc/grpc-go/blob/25b4a426b40c26c07c80af674b03db90b5bd4a60/transport/http2_client.go#L125
 func isTemporary(err error) bool {

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package rollbar
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -153,6 +154,21 @@ func (c *Client) SetCheckIgnore(checkIgnore func(string) bool) {
 // CaptureIpNone means do not capture anything.
 func (c *Client) SetCaptureIp(captureIp captureIp) {
 	c.configuration.captureIp = captureIp
+}
+
+// SetRetryAttempts sets how many times to attempt to retry sending an item if the http transport
+// experiences temporary error conditions. By default this is equal to DefaultRetryAttempts.
+// Temporary errors include timeouts and rate limit responses.
+func (c *Client) SetRetryAttempts(retryAttempts int) {
+	c.Transport.SetRetryAttempts(retryAttempts)
+}
+
+// SetPrintPayloadOnError sets whether or not to output the payload to the set logger or to
+// stderr if an error occurs during transport to the Rollbar API. For example, if you hit
+// your rate limit and we run out of retry attempts, then if this is true we will output the
+// item to stderr rather than the item disappearing completely.
+func (c *Client) SetPrintPayloadOnError(printPayloadOnError bool) {
+	c.Transport.SetPrintPayloadOnError(printPayloadOnError)
 }
 
 // Token is the currently set Rollbar access token.
@@ -455,29 +471,67 @@ func createConfiguration(token, environment, codeVersion, serverHost, serverRoot
 	}
 }
 
-func clientPost(token, endpoint string, body map[string]interface{}, logger ClientLogger) error {
+// clientPost returns an error which indicates the type of error that occured while attempting to
+// send the body input to the endpoint given, or nil if no error occurred. If error is not nil, the
+// boolean return parameter indicates whether the error is temporary or not. If this boolean return
+// value is true then the caller could call this function again with the same input and possibly
+// see a non-error response.
+func clientPost(token, endpoint string, body map[string]interface{}, logger ClientLogger) (error, bool) {
 	if len(token) == 0 {
 		rollbarError(logger, "empty token")
-		return nil
+		return nil, false
 	}
 
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
 		rollbarError(logger, "failed to encode payload: %s", err.Error())
-		return err
+		return err, false
 	}
 
 	resp, err := http.Post(endpoint, "application/json", bytes.NewReader(jsonBody))
 	if err != nil {
 		rollbarError(logger, "POST failed: %s", err.Error())
-		return err
+		return err, isTemporary(err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		rollbarError(logger, "received response: %s", resp.Status)
-		return ErrHTTPError(resp.StatusCode)
+		// http.StatusTooManyRequests is only defined in Go 1.6+ so we use 429 directly
+		isRateLimit := resp.StatusCode == 429
+		return ErrHTTPError(resp.StatusCode), isRateLimit
 	}
 
-	return nil
+	return nil, false
+}
+
+// isTemporary returns true if we should continue the error returned from http.Post to be temporary
+// in nature and possibly resolvable by simplying trying the request again.
+// https://github.com/grpc/grpc-go/blob/25b4a426b40c26c07c80af674b03db90b5bd4a60/transport/http2_client.go#L125
+func isTemporary(err error) bool {
+	switch err {
+	case io.EOF:
+		// Connection closures may be resolved upon retry, and are thus
+		// treated as temporary.
+		return true
+	case context.DeadlineExceeded:
+		// In Go 1.7, context.DeadlineExceeded implements Timeout(), and this
+		// special case is not needed. Until then, we need to keep this
+		// clause.
+		return true
+	}
+
+	switch err := err.(type) {
+	case interface {
+		Temporary() bool
+	}:
+		return err.Temporary()
+	case interface {
+		Timeout() bool
+	}:
+		// Timeouts may be resolved upon retry, and are thus treated as
+		// temporary.
+		return err.Timeout()
+	}
+	return false
 }

--- a/client_test.go
+++ b/client_test.go
@@ -23,6 +23,8 @@ func (t *TestTransport) Wait() {
 func (t *TestTransport) SetToken(_t string)                {}
 func (t *TestTransport) SetEndpoint(_e string)             {}
 func (t *TestTransport) SetLogger(_l rollbar.ClientLogger) {}
+func (t *TestTransport) SetRetryAttempts(_r int) {}
+func (t *TestTransport) SetPrintPayloadOnError(_p bool) {}
 func (t *TestTransport) Send(body map[string]interface{}) error {
 	t.Body = body
 	return nil

--- a/client_test.go
+++ b/client_test.go
@@ -23,8 +23,8 @@ func (t *TestTransport) Wait() {
 func (t *TestTransport) SetToken(_t string)                {}
 func (t *TestTransport) SetEndpoint(_e string)             {}
 func (t *TestTransport) SetLogger(_l rollbar.ClientLogger) {}
-func (t *TestTransport) SetRetryAttempts(_r int) {}
-func (t *TestTransport) SetPrintPayloadOnError(_p bool) {}
+func (t *TestTransport) SetRetryAttempts(_r int)           {}
+func (t *TestTransport) SetPrintPayloadOnError(_p bool)    {}
 func (t *TestTransport) Send(body map[string]interface{}) error {
 	t.Body = body
 	return nil

--- a/doc.go
+++ b/doc.go
@@ -7,6 +7,7 @@ Basic Usage
 
   import (
     "github.com/rollbar/rollbar-go"
+    "time"
   )
 
   func main() {
@@ -16,15 +17,13 @@ Basic Usage
     rollbar.SetServerHost("web.1")                       // optional override; defaults to hostname
     rollbar.SetServerRoot("github.com/heroku/myproject") // path of project (required for GitHub integration and non-project stacktrace collapsing)
 
-    // Assuming DoSomething is defined elsewhere
-    result, err := DoSomething()
-    if err != nil {
-      rollbar.Critical(err)
-    }
-
     rollbar.Info("Message body goes here")
+    rollbar.WrapAndWait(doSomething)
+  }
 
-    rollbar.Wait()
+  func doSomething() {
+    var timer *time.Timer = nil
+    timer.Reset(10) // this will panic
   }
 
 

--- a/rollbar.go
+++ b/rollbar.go
@@ -145,6 +145,22 @@ func SetCaptureIp(captureIp captureIp) {
 	std.SetCaptureIp(captureIp)
 }
 
+// SetRetryAttempts sets how many times to attempt to retry sending an item if the http transport
+// experiences temporary error conditions. By default this is equal to DefaultRetryAttempts.
+// Temporary errors include timeouts and rate limit responses.
+func SetRetryAttempts(retryAttempts int) {
+	std.SetRetryAttempts(retryAttempts)
+}
+
+// SetPrintPayloadOnError sets whether or not to output the payload to stderr if an error occurs
+// during transport to the Rollbar API. For example, if you hit your rate limit and we run out
+// of retry attempts, then if this is true we will output the item to stderr rather than the
+// item disappearing completely.
+// By default this is true.
+func SetPrintPayloadOnError(printPayloadOnError bool) {
+	std.SetPrintPayloadOnError(printPayloadOnError)
+}
+
 // -- Getters
 
 // Token returns the currently set Rollbar access token on the managed Client instance.

--- a/sync_transport.go
+++ b/sync_transport.go
@@ -11,14 +11,23 @@ type SyncTransport struct {
 	// when the Rollbar API returns 409 Too Many Requests response.
 	// If not set, the client will use the standard log.Printf by default.
 	Logger ClientLogger
+	// RetryAttempts is how often to attempt to resend an item when a temporary network error occurs
+	// This defaults to DefaultRetryAttempts
+	// Set this value to 0 if you do not want retries to happen
+	RetryAttempts int
+	// PrintPayloadOnError is whether or not to output the payload to the set logger or to stderr if
+	// an error occurs during transport to the Rollbar API.
+	PrintPayloadOnError bool
 }
 
 // NewSyncTransport builds a synchronous transport which sends data to the Rollbar API at the
 // specified endpoint using the given access token.
 func NewSyncTransport(token, endpoint string) *SyncTransport {
 	return &SyncTransport{
-		Token:    token,
-		Endpoint: endpoint,
+		Token:               token,
+		Endpoint:            endpoint,
+		RetryAttempts:       DefaultRetryAttempts,
+		PrintPayloadOnError: true,
 	}
 }
 
@@ -27,7 +36,21 @@ func NewSyncTransport(token, endpoint string) *SyncTransport {
 // If the access token has not been set or is empty then this will
 // not send anything and will return nil.
 func (t *SyncTransport) Send(body map[string]interface{}) error {
-	return clientPost(t.Token, t.Endpoint, body, t.Logger)
+	return t.doSend(body, t.RetryAttempts)
+}
+
+func (t *SyncTransport) doSend(body map[string]interface{}, retriesLeft int) error {
+	err, canRetry := clientPost(t.Token, t.Endpoint, body, t.Logger)
+	if err != nil {
+		if !canRetry || retriesLeft <= 0 {
+			if t.PrintPayloadOnError {
+				writePayloadToStderr(t.Logger, body)
+			}
+			return err
+		}
+		return t.doSend(body, retriesLeft-1)
+	}
+	return nil
 }
 
 // Wait is a no-op for the synchronous transport.
@@ -52,4 +75,17 @@ func (t *SyncTransport) SetEndpoint(endpoint string) {
 // processing items.
 func (t *SyncTransport) SetLogger(logger ClientLogger) {
 	t.Logger = logger
+}
+
+// SetRetryAttempts is how often to attempt to resend an item when a temporary network error occurs
+// This defaults to DefaultRetryAttempts
+// Set this value to 0 if you do not want retries to happen
+func (t *SyncTransport) SetRetryAttempts(retryAttempts int) {
+	t.RetryAttempts = retryAttempts
+}
+
+// SetPrintPayloadOnError is whether or not to output the payload to stderr if an error occurs during
+// transport to the Rollbar API.
+func (t *SyncTransport) SetPrintPayloadOnError(printPayloadOnError bool) {
+	t.PrintPayloadOnError = printPayloadOnError
 }


### PR DESCRIPTION
If an error occurs during transport such as a TLS timeout we attempt to
retry sending the item. We do this a fixed number of times. Once the
fixed number of attempts has exhausted we declare that a failure. We
also print the full payload to stderr or to the configured logger in the
event of a failure so at least the item shows up somewhere rather than
completely getting lost. Both the number of retries and whether or not
to print the item is configurable. The defaults are 3 retries and true
for printing.

We could arguably have more complex retry behaviour like adding some
backoff, but these are really only for very transient errors so adding
that complexity would be a next step.

Fixes #37 