### PR TITLE
Accept a call scoped context throughout the logging functions

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/rollbar/rollbar-go"
@@ -22,7 +23,10 @@ func helloJson(w http.ResponseWriter, r *http.Request) {
 		fmt.Println("key:", k)
 		fmt.Println("val:", v)
 	}
-	rollbar.Info(r, "Example message json")
+	// This person context will override the global value set with SetPerson in main for the
+	// specific call that it is sent with.
+	ctx := rollbar.NewPersonContext(context.TODO(), &rollbar.Person{Id: "42", Username: "Frank", Email: ""})
+	rollbar.Info(r, "Example message json", ctx)
 	fmt.Fprintf(w, "Hello world!")
 }
 
@@ -34,6 +38,7 @@ func helloForm(w http.ResponseWriter, r *http.Request) {
 		fmt.Println("key:", k)
 		fmt.Println("val:", strings.Join(v, " "))
 	}
+	// Without a context this will include the person from the global SetPerson call
 	rollbar.Info(r, "Example message form")
 	fmt.Fprintf(w, "Hello world!")
 }
@@ -42,11 +47,15 @@ func helloForm(w http.ResponseWriter, r *http.Request) {
 // In another:
 //    curl -X POST -H "Content-Type: application/x-www-form-urlencoded" \
 //      http://localhost:9090/form -d "password=foobar&fuzz=buzz"
+// Or:
+//    curl -X POST -H "Content-Type: application/json" \
+//      http://localhost:9090/json -d '{"password":"foobar","fuzz":"buzz"}'
 func main() {
 	var token = os.Getenv("TOKEN")
 	rollbar.SetToken(token)
 	rollbar.SetEnvironment("test")
 	rollbar.SetCaptureIp(rollbar.CaptureIpAnonymize)
+	rollbar.SetPerson("88", "Steve", "")
 	http.HandleFunc("/json", helloJson)
 	http.HandleFunc("/form", helloForm)
 	err := http.ListenAndServe(":9090", nil)

--- a/rollbar.go
+++ b/rollbar.go
@@ -1,6 +1,7 @@
 package rollbar
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"regexp"
@@ -338,6 +339,7 @@ func Log(level string, interfaces ...interface{}) {
 	skipSet := false
 	var extras map[string]interface{}
 	var msg string
+	ctx := context.TODO()
 	for _, ival := range interfaces {
 		switch val := ival.(type) {
 		case *http.Request:
@@ -351,6 +353,8 @@ func Log(level string, interfaces ...interface{}) {
 			msg = val
 		case map[string]interface{}:
 			extras = val
+		case context.Context:
+			ctx = val
 		default:
 			rollbarError(std.Transport.(*AsyncTransport).Logger, "Unknown input type: %T", val)
 		}
@@ -360,15 +364,15 @@ func Log(level string, interfaces ...interface{}) {
 	}
 	if err != nil {
 		if r == nil {
-			std.ErrorWithStackSkipWithExtras(level, err, skip, extras)
+			std.ErrorWithStackSkipWithExtrasAndContext(ctx, level, err, skip, extras)
 		} else {
-			std.RequestErrorWithStackSkipWithExtras(level, r, err, skip, extras)
+			std.RequestErrorWithStackSkipWithExtrasAndContext(ctx, level, r, err, skip, extras)
 		}
 	} else {
 		if r == nil {
-			std.MessageWithExtras(level, msg, extras)
+			std.MessageWithExtrasAndContext(ctx, level, msg, extras)
 		} else {
-			std.RequestMessageWithExtras(level, r, msg, extras)
+			std.RequestMessageWithExtrasAndContext(ctx, level, r, msg, extras)
 		}
 	}
 }
@@ -391,6 +395,12 @@ func ErrorWithExtras(level string, err error, extras map[string]interface{}) {
 	std.ErrorWithExtras(level, err, extras)
 }
 
+// ErrorWithExtrasAndContext asynchronously sends an error to Rollbar with the given
+// severity level with extra custom data, within the given context.
+func ErrorWithExtrasAndContext(ctx context.Context, level string, err error, extras map[string]interface{}) {
+	std.ErrorWithExtrasAndContext(ctx, level, err, extras)
+}
+
 // RequestError asynchronously sends an error to Rollbar with the given
 // severity level and request-specific information.
 func RequestError(level string, r *http.Request, err error) {
@@ -401,6 +411,12 @@ func RequestError(level string, r *http.Request, err error) {
 // severity level and request-specific information with extra custom data.
 func RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{}) {
 	std.RequestErrorWithExtras(level, r, err, extras)
+}
+
+// RequestErrorWithExtrasAndContext asynchronously sends an error to Rollbar with the given
+// severity level and request-specific information with extra custom data.
+func RequestErrorWithExtrasAndContext(ctx context.Context, level string, r *http.Request, err error, extras map[string]interface{}) {
+	std.RequestErrorWithExtrasAndContext(ctx, level, r, err, extras)
 }
 
 // ErrorWithStackSkip asynchronously sends an error to Rollbar with the given
@@ -415,6 +431,14 @@ func ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[
 	std.ErrorWithStackSkipWithExtras(level, err, skip, extras)
 }
 
+// ErrorWithStackSkipWithExtrasAndContext asynchronously sends an error to Rollbar with the given
+// severity level and a given number of stack trace frames skipped with extra custom data, within
+// the given context.
+func ErrorWithStackSkipWithExtrasAndContext(ctx context.Context, level string, err error, skip int, extras map[string]interface{}) {
+	std.ErrorWithStackSkipWithExtrasAndContext(ctx, level, err, skip, extras)
+}
+
+// RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
 // RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
 // given severity level and a given number of stack trace frames skipped, in
 // addition to extra request-specific information.
@@ -427,6 +451,13 @@ func RequestErrorWithStackSkip(level string, r *http.Request, err error, skip in
 // in addition to extra request-specific information and extra custom data.
 func RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
 	std.RequestErrorWithStackSkipWithExtras(level, r, err, skip, extras)
+}
+
+// RequestErrorWithStackSkipWithExtrasAndContext asynchronously sends an error to Rollbar
+// with the given severity level and a given number of stack trace frames skipped,
+// in addition to extra request-specific information and extra custom data, within the given context.
+func RequestErrorWithStackSkipWithExtrasAndContext(ctx context.Context, level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
+	std.RequestErrorWithStackSkipWithExtrasAndContext(ctx, level, r, err, skip, extras)
 }
 
 // -- Message reporting
@@ -443,6 +474,12 @@ func MessageWithExtras(level string, msg string, extras map[string]interface{}) 
 	std.MessageWithExtras(level, msg, extras)
 }
 
+// MessageWithExtrasAndContext asynchronously sends a message to Rollbar with the given severity
+// level with extra custom data, within the given context. Rollbar request is asynchronous.
+func MessageWithExtrasAndContext(ctx context.Context, level string, msg string, extras map[string]interface{}) {
+	std.MessageWithExtrasAndContext(ctx, level, msg, extras)
+}
+
 // RequestMessage asynchronously sends a message to Rollbar with the given
 // severity level and request-specific information.
 func RequestMessage(level string, r *http.Request, msg string) {
@@ -454,6 +491,13 @@ func RequestMessage(level string, r *http.Request, msg string) {
 // Rollbar request is asynchronous.
 func RequestMessageWithExtras(level string, r *http.Request, msg string, extras map[string]interface{}) {
 	std.RequestMessageWithExtras(level, r, msg, extras)
+}
+
+// RequestMessageWithExtrasAndContext asynchronously sends a message to Rollbar with the given severity
+// level with extra custom data in addition to extra request-specific information, within the given
+// context. Rollbar request is asynchronous.
+func RequestMessageWithExtrasAndContext(ctx context.Context, level string, r *http.Request, msg string, extras map[string]interface{}) {
+	std.RequestMessageWithExtrasAndContext(ctx, level, r, msg, extras)
 }
 
 // Wait will block until the queue of errors / messages is empty.

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -1,6 +1,7 @@
 package rollbar
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -153,7 +154,7 @@ func TestBuildBody(t *testing.T) {
 		"EXTRA_CUSTOM_KEY":      "EXTRA_CUSTOM_VALUE",
 		"OVERRIDDEN_CUSTOM_KEY": "EXTRA",
 	}
-	body := interface{}(std).(*Client).buildBody(ERR, "test error", extraCustom)
+	body := interface{}(std).(*Client).buildBody(context.TODO(), ERR, "test error", extraCustom)
 
 	if body["data"] == nil {
 		t.Error("body should have data")
@@ -182,7 +183,7 @@ func TestBuildBodyNoBaseCustom(t *testing.T) {
 		"EXTRA_CUSTOM_KEY":      "EXTRA_CUSTOM_VALUE",
 		"OVERRIDDEN_CUSTOM_KEY": "EXTRA",
 	}
-	body := interface{}(std).(*Client).buildBody(ERR, "test error", extraCustom)
+	body := interface{}(std).(*Client).buildBody(context.TODO(), ERR, "test error", extraCustom)
 
 	if body["data"] == nil {
 		t.Error("body should have data")

--- a/transforms.go
+++ b/transforms.go
@@ -1,6 +1,7 @@
 package rollbar
 
 import (
+	"context"
 	"fmt"
 	"hash/adler32"
 	"net/http"
@@ -13,7 +14,7 @@ import (
 
 // Build the main JSON structure that will be sent to Rollbar with the
 // appropriate metadata.
-func buildBody(configuration configuration, level, title string, extras map[string]interface{}) map[string]interface{} {
+func buildBody(ctx context.Context, configuration configuration, level, title string, extras map[string]interface{}) map[string]interface{} {
 	timestamp := time.Now().Unix()
 
 	data := map[string]interface{}{
@@ -39,12 +40,15 @@ func buildBody(configuration configuration, level, title string, extras map[stri
 		data["custom"] = custom
 	}
 
-	person := configuration.person
-	if person.id != "" {
+	person, ok := PersonFromContext(ctx)
+	if !ok {
+		person = &configuration.person
+	}
+	if person.Id != "" {
 		data["person"] = map[string]string{
-			"id":       person.id,
-			"username": person.username,
-			"email":    person.email,
+			"id":       person.Id,
+			"username": person.Username,
+			"email":    person.Email,
 		}
 	}
 


### PR DESCRIPTION
The impetus of this change was to provide a simple mechanism for setting
the Person for a particular error message without setting it globally.
The globally SetPerson mechanism works for certain use cases, but for
many others you want to scope the Person to a smaller surface area. This
change introduces a context.Context to most (all?) of the logging
methods. For now this only is used to possibly pass a Person to the
particular call by using `NewPersonContext`. I decided to use a context
rather than accepting a person struct so that we could possibly use this
context for cancellation and timeouts in the future, or other scoped
values.

I added a usage to the example. Most of the tests hit these code paths,
but some additional tests might be welcome.