### PR TITLE
Add support for pkg/errors stack trace extraction

### DIFF
--- a/client.go
+++ b/client.go
@@ -162,6 +162,14 @@ func (c *Client) SetTransform(transform func(map[string]interface{})) {
 	c.configuration.transform = transform
 }
 
+// SetStackTracer sets the stackTracer function which is called to extract the stack
+// trace from enhanced error types. Return nil if no trace information is available.
+// Return true if the error type can be handled and false otherwise.
+// This feature can be used to add support for custom error type stack trace extraction.
+func (c *Client) SetStackTracer(stackTracer func(err error) ([]runtime.Frame, bool)) {
+	c.configuration.stackTracer = stackTracer
+}
+
 // SetCheckIgnore sets the checkIgnore function which is called during the recovery
 // process of a panic that occurred inside a function wrapped by Wrap or WrapAndWait.
 // Return true if you wish to ignore this panic, false if you wish to
@@ -543,6 +551,7 @@ type configuration struct {
 	scrubFields  *regexp.Regexp
 	checkIgnore  func(string) bool
 	transform    func(map[string]interface{})
+	stackTracer  func(error) ([]runtime.Frame, bool)
 	person       Person
 	captureIp    captureIp
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,44 @@
+package errors
+
+import (
+	"runtime"
+
+	pkgerr "github.com/pkg/errors"
+)
+
+// StackTracer is able to extract stack traces from pkg/errors.
+func StackTracer(err error) ([]runtime.Frame, bool) {
+	type stackTracer interface {
+		StackTrace() pkgerr.StackTrace
+	}
+
+	switch x := err.(type) {
+	case stackTracer:
+		st := x.StackTrace()
+		pcs := make([]uintptr, len(st))
+		for i, pc := range st {
+			pcs[i] = uintptr(pc)
+		}
+		fr := runtime.CallersFrames(pcs)
+
+		return framesToSlice(fr), true
+	}
+
+	return nil, false
+}
+
+// framesToSlice extracts all the runtime.Frame from runtime.Frames.
+// This function has been copied from transform.go in rollbar-go.
+func framesToSlice(fr *runtime.Frames) []runtime.Frame {
+	frames := make([]runtime.Frame, 0)
+
+	for frame, more := fr.Next(); frame != (runtime.Frame{}); frame, more = fr.Next() {
+		frames = append(frames, frame)
+
+		if !more {
+			break
+		}
+	}
+
+	return frames
+}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,49 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	pkgerr "github.com/pkg/errors"
+)
+
+func TestStackTracerOfPkgErrorsWithoutParent(t *testing.T) {
+	err := pkgerr.New("")
+	frs, ok := StackTracer(err)
+	if !ok {
+		t.Errorf("got: unsupported type")
+	}
+
+	fr := frs[0]
+	if !strings.HasSuffix(fr.File, "rollbar-go/errors/errors_test.go") {
+		t.Errorf("got: %s", fr.File)
+	}
+	if fr.Function != "github.com/rollbar/rollbar-go/errors.TestStackTracerOfPkgErrorsWithoutParent" {
+		t.Errorf("got: %s", fr.Function)
+	}
+	if fr.Line != 12 {
+		t.Errorf("got: %d", fr.Line)
+	}
+}
+
+func TestStackTracerOfPkgErrorsWithParent(t *testing.T) {
+	cause := fmt.Errorf("cause")
+	effect := pkgerr.Wrap(cause, "effect")
+	effect2 := pkgerr.Wrap(effect, "effect2")
+	frs, ok := StackTracer(effect2)
+	if !ok {
+		t.Errorf("got: unsupported type")
+	}
+
+	fr := frs[0]
+	if !strings.HasSuffix(fr.File, "rollbar-go/errors/errors_test.go") {
+		t.Errorf("got: %s", fr.File)
+	}
+	if fr.Function != "github.com/rollbar/rollbar-go/errors.TestStackTracerOfPkgErrorsWithParent" {
+		t.Errorf("got: %s", fr.Function)
+	}
+	if fr.Line != 33 {
+		t.Errorf("got: %d", fr.Line)
+	}
+}

--- a/errors/go.mod
+++ b/errors/go.mod
@@ -1,0 +1,3 @@
+module github.com/rollbar/rollbar-go/errors
+
+require github.com/pkg/errors v0.8.1

--- a/errors/go.sum
+++ b/errors/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/rollbar/rollbar-go
+
+require github.com/pkg/errors v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/rollbar/rollbar-go
-
-require github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/rollbar.go
+++ b/rollbar.go
@@ -126,6 +126,15 @@ func SetTransform(transform func(map[string]interface{})) {
 	std.SetTransform(transform)
 }
 
+// SetStackTracer sets the stackTracer function on the managed Client instance.
+// StackTracer is called to extract the stack trace from enhanced error types.
+// Return nil if no trace information is available. Return true if the error type
+// can be handled and false otherwise.
+// This feature can be used to add support for custom error type stack trace extraction.
+func SetStackTracer(stackTracer func(err error) ([]runtime.Frame, bool)) {
+	std.SetStackTracer(stackTracer)
+}
+
 // SetCheckIgnore sets the checkIgnore function on the managed Client instance.
 // CheckIgnore is called during the recovery process of a panic that
 // occurred inside a function wrapped by Wrap or WrapAndWait.


### PR DESCRIPTION
This PR concludes my current efforts with rollbar-go by adding the [discussed-about ](https://github.com/rollbar/rollbar-go/issues/45#issuecomment-453301866) support for another interface, beyond CauseStacker, to get pre-made stack traces from errors. It builds upon the previous PRs I submitted (#51 and #52).

Using these three PRs it's now a bit easier to continue adding support for other interfaces, for those who wish. The one downside to adding support for external interfaces that utilize custom structs (such as `stackTracer` from [pkg/errors](https://github.com/pkg/errors)) is the added dependencies. E.g. with this PR, rollbar-go now has a 3rd party dependency compared to before when it had zero.

A solution to 3rd party dependency cluttering could be to instead add a function property that the user can set, that will receive the error and that should return `[]runtime.Frame` or nil (in case it does not know how to extract the stack trace). If this function is set, it is called by `getOrBuildFrames` to retrieve the stack trace if possible. That way, rollbar-go would not need any more dependencies. However, obviously you lose out on the plug n' play aspect.

Nonetheless, this code is currently in use in production and works well in terms of propagating the pkg/errors stack traces to rollbar instead of generating new ones.