### PR TITLE
Provide a Close mechanism to clean up the default transport goroutine

### DIFF
--- a/async_transport.go
+++ b/async_transport.go
@@ -107,6 +107,7 @@ func (t *AsyncTransport) Wait() {
 
 // Close is an alias for Wait for the asynchronous transport
 func (t *AsyncTransport) Close() error {
+	close(t.bodyChannel)
 	t.Wait()
 	return nil
 }

--- a/rollbar.go
+++ b/rollbar.go
@@ -506,6 +506,12 @@ func Wait() {
 	std.Wait()
 }
 
+// Close will block until the queue of errors / messages is empty and terminate the goroutine used
+// for sending items.
+func Close() {
+	std.Close()
+}
+
 // Wrap calls f and then recovers and reports a panic to Rollbar if it occurs.
 // If an error is captured it is subsequently returned.
 func Wrap(f func()) interface{} {

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -139,7 +139,7 @@ func TestEverythingGeneric(t *testing.T) {
 		"hello": "request",
 	})
 
-	Wait()
+	Close()
 }
 
 func TestBuildBody(t *testing.T) {

--- a/stack_test.go
+++ b/stack_test.go
@@ -8,7 +8,7 @@ import (
 func TestBuildStack(t *testing.T) {
 	frame := buildStack(getCallersFrames(0))[0]
 
-	if !strings.HasSuffix(frame.Filename,"rollbar-go/stack_test.go") {
+	if !strings.HasSuffix(frame.Filename, "rollbar-go/stack_test.go") {
 		t.Errorf("got: %s", frame.Filename)
 	}
 	if frame.Method != "rollbar-go.TestBuildStack" {

--- a/transforms.go
+++ b/transforms.go
@@ -196,7 +196,7 @@ func errorBody(configuration configuration, err error, skip int) (map[string]int
 	traceChain := []map[string]interface{}{}
 	fingerprint := ""
 	for {
-		stack := buildStack(getOrBuildFrames(err, parent, 1 + skip))
+		stack := buildStack(getOrBuildFrames(err, parent, 1+skip))
 		traceChain = append(traceChain, buildTrace(err, stack))
 		if configuration.fingerprint {
 			fingerprint = fingerprint + stack.Fingerprint()
@@ -247,7 +247,7 @@ func getOrBuildFrames(err error, parent error, skip int) []runtime.Frame {
 
 func getCallersFrames(skip int) []runtime.Frame {
 	pc := make([]uintptr, 100)
-	runtime.Callers(2 + skip, pc)
+	runtime.Callers(2+skip, pc)
 	fr := runtime.CallersFrames(pc)
 	frames := make([]runtime.Frame, 0)
 


### PR DESCRIPTION
Fixes #48

By default when you import rollbar we create an async transport as part
of a default client so that the top level functions for reporting items
just work. However, that leads to a goroutine that dangles if you don't
actually use anything or don't want to use that standard client. This PR
adds `Close` to the top level to call Close on the standard client. We
also make `Close` close the underlying channel which is used for
communication to the goroutine used to process items. As a consequence,
once all items have been sent this goroutine will shutdown. So if you
never use it, Close will effectively just shut the goroutine down.