### PR TITLE
Add support for `x-forwarded-for` header

### DIFF
--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -221,6 +221,33 @@ func TestErrorRequest(t *testing.T) {
 	}
 }
 
+func TestRequestForwardedIP(t *testing.T) {
+	SetCaptureIp(CaptureIpFull)
+	r, _ := http.NewRequest("GET", "http://foo.com/somethere?param1=true", nil)
+	r.RemoteAddr = "1.1.1.1:123"
+	r.Header.Add("X-Forwarded-For", "1.2.3.4, 2.3.4.5, 3.4.5.6")
+
+	object := std.requestDetails(r)
+
+	if object["user_ip"] != "1.2.3.4" {
+		t.Errorf("wrong user_ip, got %v", object["user_ip"])
+	}
+}
+
+func TestRequestMutlipleIPHeaders(t *testing.T) {
+	SetCaptureIp(CaptureIpFull)
+	r, _ := http.NewRequest("GET", "http://foo.com/somethere?param1=true", nil)
+	r.RemoteAddr = "1.1.1.1:123"
+	r.Header.Add("X-Real-Ip", "8.9.10.11")
+	r.Header.Add("X-Forwarded-For", "1.2.3.4, 2.3.4.5, 3.4.5.6")
+
+	object := std.requestDetails(r)
+
+	if object["user_ip"] != "8.9.10.11" {
+		t.Errorf("wrong user_ip, got %v", object["user_ip"])
+	}
+}
+
 func TestErrorRequestHeaders(t *testing.T) {
 	r, _ := http.NewRequest("GET", "http://foo.com/somethere?param1=true", nil)
 	r.RemoteAddr = "1.1.1.1:123"

--- a/stack_test.go
+++ b/stack_test.go
@@ -8,7 +8,7 @@ import (
 func TestBuildStack(t *testing.T) {
 	frame := buildStack(getCallersFrames(0))[0]
 
-	if !strings.HasSuffix(frame.Filename,"rollbar-go/stack_test.go") {
+	if !strings.HasSuffix(frame.Filename, "rollbar-go/stack_test.go") {
 		t.Errorf("got: %s", frame.Filename)
 	}
 	if frame.Method != "rollbar-go.TestBuildStack" {

--- a/transforms.go
+++ b/transforms.go
@@ -107,13 +107,13 @@ func requestDetails(configuration configuration, r *http.Request) map[string]int
 // remoteIP attempts to extract the real remote IP address by looking first at the headers X-Real-IP
 // and X-Forwarded-For, and then falling back to RemoteAddr defined in http.Request
 func remoteIP(req *http.Request) string {
-	real_ip := req.Header.Get("X-Real-IP")
-	if real_ip != "" {
-		return real_ip
+	realIP := req.Header.Get("X-Real-IP")
+	if realIP != "" {
+		return realIP
 	}
-	forwarded_ips := req.Header.Get("X-Forwarded-For")
-	if forwarded_ips != "" {
-		ips := strings.Split(forwarded_ips, ", ")
+	forwardedIPs := req.Header.Get("X-Forwarded-For")
+	if forwardedIPs != "" {
+		ips := strings.Split(forwardedIPs, ", ")
 		return ips[0]
 	}
 	return req.RemoteAddr


### PR DESCRIPTION
Fixes #49

We now support `X-Real-IP` and `X-Forwarded-For` as the value that gets put
into `user_ip` if one is set, otherwise we still fallback to `RemoteAddr`.