### PR TITLE
Use actual error class name  for default error type

### DIFF
--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -44,7 +44,9 @@ func testErrorStackWithSkipGeneric2(s string) {
 
 func TestErrorClass(t *testing.T) {
 	errors := map[string]error{
-		"{4b81076c}":          fmt.Errorf("something is broken"),
+		// generic error
+		"errors.errorString":          fmt.Errorf("something is broken"),
+		// custom error
 		"rollbar.CustomError": &CustomError{"terrible mistakes were made"},
 	}
 

--- a/transforms.go
+++ b/transforms.go
@@ -2,8 +2,6 @@ package rollbar
 
 import (
 	"context"
-	"fmt"
-	"hash/adler32"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -294,9 +292,6 @@ func errorClass(err error) string {
 	class := reflect.TypeOf(err).String()
 	if class == "" {
 		return "panic"
-	} else if class == "*errors.errorString" {
-		checksum := adler32.Checksum([]byte(err.Error()))
-		return fmt.Sprintf("{%x}", checksum)
 	} else {
 		return strings.TrimPrefix(class, "*")
 	}


### PR DESCRIPTION
Grouping in the dashboard gets scrambled when sending hash strings as the error class. The current grouping logic is smart enough to use back trace and other signals to bucket these.