### PR TITLE
Diagnostic info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: go
 
 go:
+  - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
   - master
+
+matrix:
+  allow_failures:
+    go: 1.7.x

--- a/client_test.go
+++ b/client_test.go
@@ -8,8 +8,6 @@ import (
 	"reflect"
 	"testing"
 	"strings"
-	rollbarErrors "github.com/rollbar/rollbar-go/errors"
-	pkgerr "github.com/pkg/errors"
 )
 
 type TestTransport struct {
@@ -458,31 +456,6 @@ func TestTransform(t *testing.T) {
 		configuredOptions := configuredOptionsFromData(data)
 		if !strings.Contains(configuredOptions["transform"].(string), "TestTransform.func1") {
 			t.Error("data should have transform in diagnostic object")
-		}
-	} else {
-		t.Fail()
-	}
-}
-
-func TestStackTracer(t *testing.T) {
-	client := testClient()
-	client.SetStackTracer(rollbarErrors.StackTracer)
-
-	client.ErrorWithLevel(rollbar.ERR, pkgerr.New("Bork"))
-
-	if transport, ok := client.Transport.(*TestTransport); ok {
-		body := transport.Body
-		if body["data"] == nil {
-			t.Error("body should have data")
-		}
-		data := body["data"].(map[string]interface{})
-		framesLen := framesLenFromData(data)
-		if framesLen == 0 {
-			t.Error("data should have frames set by stackTracer")
-		}
-		configuredOptions := configuredOptionsFromData(data)
-		if !strings.Contains(configuredOptions["stackTracer"].(string), "errors.StackTracer") {
-			t.Error("data should have stackTracer in diagnostic object")
 		}
 	} else {
 		t.Fail()

--- a/client_test.go
+++ b/client_test.go
@@ -499,7 +499,7 @@ func configuredOptionsFromData(data map[string]interface{}) map[string]interface
 
 func framesLenFromData(data map[string]interface{}) int {
 	body := data["body"].(map[string]interface{})
-	trace_chain := body["trace_chain"].([]map[string]interface{})
-	frames := reflect.ValueOf(trace_chain[0]["frames"])
+	traceChain := body["trace_chain"].([]map[string]interface{})
+	frames := reflect.ValueOf(traceChain[0]["frames"])
 	return frames.Len()
 }

--- a/transforms.go
+++ b/transforms.go
@@ -13,7 +13,9 @@ import (
 
 // Build the main JSON structure that will be sent to Rollbar with the
 // appropriate metadata.
-func buildBody(ctx context.Context, configuration configuration, level, title string, extras map[string]interface{}) map[string]interface{} {
+func buildBody(ctx context.Context, configuration configuration, diagnostic diagnostic,
+	level, title string, extras map[string]interface{}) map[string]interface{} {
+
 	timestamp := time.Now().Unix()
 
 	data := map[string]interface{}{
@@ -31,6 +33,10 @@ func buildBody(ctx context.Context, configuration configuration, level, title st
 		"notifier": map[string]interface{}{
 			"name":    NAME,
 			"version": VERSION,
+			"diagnostic": map[string]interface{}{
+				"languageVersion": diagnostic.languageVersion,
+				"configuredOptions": diagnostic.configuredOptions,
+			},
 		},
 	}
 


### PR DESCRIPTION
1. Send diagnostic info in the payload:
* Go version
* Configured Options

This brings rollbar-go into sync with work done previously in other SDKs.

2. The travis matrix is updated to include recent Go versions, and evaluates older versions in the `allow_failures` key.

3. Updated tests for config options.
