### PR TITLE
Wrap functions with arguments, and add Rollbar to defer/recover functions

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -84,7 +84,7 @@ func TestWrap(t *testing.T) {
 func TestWrapWithArgs(t *testing.T) {
 	client := testClient()
 	result := client.Wrap(func(foo string, num int) (string, int) {
-		panic(errors.New(fmt.Sprintf("%v-%v", foo, num)))
+		panic(fmt.Errorf("%v-%v", foo, num))
 	}, "foo", 42)
 	if fmt.Sprintf("%T", result) != "*errors.errorString" {
 		t.Error("Return value should be error type")

--- a/rollbar.go
+++ b/rollbar.go
@@ -588,17 +588,31 @@ func Close() {
 	std.Close()
 }
 
+// LogPanic accepts an error value returned by recover() and
+// handles logging to Rollbar with stack info.
+func LogPanic(err interface{}, wait bool) {
+	std.LogPanic(err, wait)
+}
+
+// WrapWithArgs calls f with the supplied args and reports a panic to Rollbar if it occurs.
+// If wait is true, this also waits before returning to ensure the message was reported.
+// If an error is captured it is subsequently returned.
+// WrapWithArgs is compatible with any return type for f, but does not return its return value(s).
+func WrapWithArgs(f interface{}, wait bool, args ...interface{}) interface{} {
+	return std.WrapWithArgs(f, wait, args...)
+}
+
 // Wrap calls f and then recovers and reports a panic to Rollbar if it occurs.
 // If an error is captured it is subsequently returned.
-func Wrap(f func()) interface{} {
-	return std.Wrap(f)
+func Wrap(f interface{}, args ...interface{}) interface{} {
+	return std.WrapWithArgs(f, false, args...)
 }
 
 // WrapAndWait calls f, and recovers and reports a panic to Rollbar if it occurs.
 // This also waits before returning to ensure the message was reported.
 // If an error is captured it is subsequently returned.
-func WrapAndWait(f func()) interface{} {
-	return std.WrapAndWait(f)
+func WrapAndWait(f interface{}, args ...interface{}) interface{} {
+	return std.WrapWithArgs(f, true, args...)
 }
 
 // LambdaWrapper calls handlerFunc with arguments, and recovers and reports a


### PR DESCRIPTION
`Wrap` and `WrapAndWait` are convenient for reporting unhandled panics in wrapped functions, but until now could only wrap functions with no arguments and no return values. This PR allows any function signature to be used. It also exposes a new helper, `LogPanic`, that can be used to add Rollbar reporting to any defer/recover function.

Since wrapping a function in main() won't recover panics in goroutines, and since many programs do use goroutines liberally, this extra flexibility should help make it easier to report panics wherever needed.

The updated `Wrap` and `WrapAndWait` are fully compatible with previous/existing behavior, accepting `func()` just fine, and the existing behavior of returning the error is preserved.

While `Wrap` and `WrapAndWait` can now accept functions with any return signature, they do not return the function's return value. In cases where this is needed, the `LogPanic` helper can be used to add Rollbar to the function's defer/recover handler, instead of using any wrapper. Using `LogPanic` makes the resulting defer function simple and compact:

```
func ExampleFunction() {
  defer func() {
    err := recover()
    rollbar.LogPanic(err, true) // bool argument sets wait behavior
  }()

  // function body ...
}
```

An even more streamlined `defer RollbarRecover()` helper was considered, but `recover()` only works correctly when in a closure of the containing function, not when the defer function is a separate non-closure function.