### PR TITLE
Set custom http client

### DIFF
--- a/async_transport.go
+++ b/async_transport.go
@@ -37,7 +37,7 @@ func NewAsyncTransport(token string, endpoint string, buffer int) *AsyncTranspor
 
 	go func() {
 		for p := range transport.bodyChannel {
-			err, canRetry := transport.post(p.body)
+			canRetry, err := transport.post(p.body)
 			if err != nil {
 				if canRetry && p.retriesLeft > 0 {
 					p.retriesLeft -= 1

--- a/async_transport.go
+++ b/async_transport.go
@@ -1,6 +1,7 @@
 package rollbar
 
 import (
+	"net/http"
 	"sync"
 )
 
@@ -27,6 +28,7 @@ type AsyncTransport struct {
 	PrintPayloadOnError bool
 	bodyChannel         chan payload
 	waitGroup           sync.WaitGroup
+	httpClient          *http.Client
 }
 
 type payload struct {
@@ -150,5 +152,17 @@ func (t *AsyncTransport) SetPrintPayloadOnError(printPayloadOnError bool) {
 }
 
 func (t *AsyncTransport) post(p payload) (error, bool) {
-	return clientPost(t.Token, t.Endpoint, p.body, t.Logger)
+	return clientPost(t.Token, t.Endpoint, p.body, t.Logger, t.getHttpClient())
+}
+
+func (t *AsyncTransport) SetHttpClient(c *http.Client) {
+	t.httpClient = c
+}
+
+func (t *AsyncTransport) getHttpClient() *http.Client {
+	if t.httpClient != nil {
+		return t.httpClient
+	}
+
+	return http.DefaultClient
 }

--- a/base_transport.go
+++ b/base_transport.go
@@ -24,7 +24,8 @@ type baseTransport struct {
 	// PrintPayloadOnError is whether or not to output the payload to the set logger or to stderr if
 	// an error occurs during transport to the Rollbar API.
 	PrintPayloadOnError bool
-	httpClient          *http.Client
+	// custom http client (http.DefaultClient used by default)
+	httpClient *http.Client
 }
 
 // SetToken updates the token to use for future API requests.
@@ -56,10 +57,12 @@ func (t *baseTransport) SetPrintPayloadOnError(printPayloadOnError bool) {
 	t.PrintPayloadOnError = printPayloadOnError
 }
 
+// SetHTTPClient sets custom http client. http.DefaultClient is used by default
 func (t *baseTransport) SetHTTPClient(c *http.Client) {
 	t.httpClient = c
 }
 
+// getHTTPClient returns either custom client (if set) or http.DefaultClient
 func (t *baseTransport) getHTTPClient() *http.Client {
 	if t.httpClient != nil {
 		return t.httpClient

--- a/base_transport.go
+++ b/base_transport.go
@@ -3,6 +3,8 @@ package rollbar
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -88,7 +90,9 @@ func (t *baseTransport) post(body map[string]interface{}) (error, bool) {
 		rollbarError(t.Logger, "POST failed: %s", err.Error())
 		return err, isTemporary(err)
 	}
-	defer resp.Body.Close()
+
+	io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		rollbarError(t.Logger, "received response: %s", resp.Status)

--- a/base_transport.go
+++ b/base_transport.go
@@ -1,0 +1,101 @@
+package rollbar
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+type baseTransport struct {
+	// Rollbar access token used by this transport for communication with the Rollbar API.
+	Token string
+	// Endpoint to post items to.
+	Endpoint string
+	// Logger used to report errors when sending data to Rollbar, e.g.
+	// when the Rollbar API returns 409 Too Many Requests response.
+	// If not set, the client will use the standard log.Printf by default.
+	Logger ClientLogger
+	// RetryAttempts is how often to attempt to resend an item when a temporary network error occurs
+	// This defaults to DefaultRetryAttempts
+	// Set this value to 0 if you do not want retries to happen
+	RetryAttempts int
+	// PrintPayloadOnError is whether or not to output the payload to the set logger or to stderr if
+	// an error occurs during transport to the Rollbar API.
+	PrintPayloadOnError bool
+	httpClient          *http.Client
+}
+
+// SetToken updates the token to use for future API requests.
+func (t *baseTransport) SetToken(token string) {
+	t.Token = token
+}
+
+// SetEndpoint updates the API endpoint to send items to.
+func (t *baseTransport) SetEndpoint(endpoint string) {
+	t.Endpoint = endpoint
+}
+
+// SetLogger updates the logger that this transport uses for reporting errors that occur while
+// processing items.
+func (t *baseTransport) SetLogger(logger ClientLogger) {
+	t.Logger = logger
+}
+
+// SetRetryAttempts is how often to attempt to resend an item when a temporary network error occurs
+// This defaults to DefaultRetryAttempts
+// Set this value to 0 if you do not want retries to happen
+func (t *baseTransport) SetRetryAttempts(retryAttempts int) {
+	t.RetryAttempts = retryAttempts
+}
+
+// SetPrintPayloadOnError is whether or not to output the payload to stderr if an error occurs during
+// transport to the Rollbar API.
+func (t *baseTransport) SetPrintPayloadOnError(printPayloadOnError bool) {
+	t.PrintPayloadOnError = printPayloadOnError
+}
+
+func (t *baseTransport) SetHTTPClient(c *http.Client) {
+	t.httpClient = c
+}
+
+func (t *baseTransport) getHttpClient() *http.Client {
+	if t.httpClient != nil {
+		return t.httpClient
+	}
+
+	return http.DefaultClient
+}
+
+// post returns an error which indicates the type of error that occurred while attempting to
+// send the body input to the endpoint given, or nil if no error occurred. If error is not nil, the
+// boolean return parameter indicates whether the error is temporary or not. If this boolean return
+// value is true then the caller could call this function again with the same input and possibly
+// see a non-error response.
+func (t *baseTransport) post(body map[string]interface{}) (error, bool) {
+	if len(t.Token) == 0 {
+		rollbarError(t.Logger, "empty token")
+		return nil, false
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		rollbarError(t.Logger, "failed to encode payload: %s", err.Error())
+		return err, false
+	}
+
+	resp, err := t.httpClient.Post(t.Endpoint, "application/json", bytes.NewReader(jsonBody))
+	if err != nil {
+		rollbarError(t.Logger, "POST failed: %s", err.Error())
+		return err, isTemporary(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		rollbarError(t.Logger, "received response: %s", resp.Status)
+		// http.StatusTooManyRequests is only defined in Go 1.6+ so we use 429 directly
+		isRateLimit := resp.StatusCode == 429
+		return ErrHTTPError(resp.StatusCode), isRateLimit
+	}
+
+	return nil, false
+}

--- a/base_transport.go
+++ b/base_transport.go
@@ -60,7 +60,7 @@ func (t *baseTransport) SetHTTPClient(c *http.Client) {
 	t.httpClient = c
 }
 
-func (t *baseTransport) getHttpClient() *http.Client {
+func (t *baseTransport) getHTTPClient() *http.Client {
 	if t.httpClient != nil {
 		return t.httpClient
 	}

--- a/client.go
+++ b/client.go
@@ -246,6 +246,7 @@ func (c *Client) SetPrintPayloadOnError(printPayloadOnError bool) {
 	c.Transport.SetPrintPayloadOnError(printPayloadOnError)
 }
 
+// SetHTTPClient sets custom http client. http.DefaultClient is used by default
 func (c *Client) SetHTTPClient(httpClient *http.Client) {
 	c.Transport.SetHTTPClient(httpClient)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -3,11 +3,13 @@ package rollbar_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/rollbar/rollbar-go"
 	"net/http"
 	"reflect"
 	"regexp"
 	"strings"
+	"testing"
 )
 
 type TestTransport struct {

--- a/client_test.go
+++ b/client_test.go
@@ -1,13 +1,14 @@
 package rollbar_test
 
 import (
+	"context"
 	"errors"
 	"github.com/rollbar/rollbar-go"
-	"regexp"
-	"context"
+	"net/http"
 	"reflect"
-	"testing"
+	"regexp"
 	"strings"
+	"testing"
 )
 
 type TestTransport struct {
@@ -28,6 +29,7 @@ func (t *TestTransport) SetEndpoint(_e string)             {}
 func (t *TestTransport) SetLogger(_l rollbar.ClientLogger) {}
 func (t *TestTransport) SetRetryAttempts(_r int)           {}
 func (t *TestTransport) SetPrintPayloadOnError(_p bool)    {}
+func (t *TestTransport) SetHTTPClient(_c *http.Client)     {}
 func (t *TestTransport) Send(body map[string]interface{}) error {
 	t.Body = body
 	return nil

--- a/rollbar.go
+++ b/rollbar.go
@@ -262,6 +262,10 @@ func SetPrintPayloadOnError(printPayloadOnError bool) {
 	std.SetPrintPayloadOnError(printPayloadOnError)
 }
 
+func SetHttpClient(httpClient *http.Client) {
+	std.SetHttpClient(httpClient)
+}
+
 // -- Getters
 
 // Token returns the currently set Rollbar access token on the managed Client instance.

--- a/rollbar.go
+++ b/rollbar.go
@@ -262,7 +262,8 @@ func SetPrintPayloadOnError(printPayloadOnError bool) {
 	std.SetPrintPayloadOnError(printPayloadOnError)
 }
 
-func SetHttpClient(httpClient *http.Client) {
+// SetHTTPClient sets custom http client. http.DefaultClient is used by default
+func SetHTTPClient(httpClient *http.Client) {
 	std.SetHTTPClient(httpClient)
 }
 

--- a/rollbar.go
+++ b/rollbar.go
@@ -263,7 +263,7 @@ func SetPrintPayloadOnError(printPayloadOnError bool) {
 }
 
 func SetHttpClient(httpClient *http.Client) {
-	std.SetHttpClient(httpClient)
+	std.SetHTTPClient(httpClient)
 }
 
 // -- Getters

--- a/sync_transport.go
+++ b/sync_transport.go
@@ -28,7 +28,7 @@ func (t *SyncTransport) Send(body map[string]interface{}) error {
 }
 
 func (t *SyncTransport) doSend(body map[string]interface{}, retriesLeft int) error {
-	err, canRetry := t.post(body)
+	canRetry, err := t.post(body)
 	if err != nil {
 		if !canRetry || retriesLeft <= 0 {
 			if t.PrintPayloadOnError {

--- a/sync_transport.go
+++ b/sync_transport.go
@@ -1,36 +1,21 @@
 package rollbar
 
-import "net/http"
-
 // SyncTransport is a concrete implementation of the Transport type which communicates with the
 // Rollbar API synchronously.
 type SyncTransport struct {
-	// Rollbar access token used by this transport for communication with the Rollbar API.
-	Token string
-	// Endpoint to post items to.
-	Endpoint string
-	// Logger used to report errors when sending data to Rollbar, e.g.
-	// when the Rollbar API returns 409 Too Many Requests response.
-	// If not set, the client will use the standard log.Printf by default.
-	Logger ClientLogger
-	// RetryAttempts is how often to attempt to resend an item when a temporary network error occurs
-	// This defaults to DefaultRetryAttempts
-	// Set this value to 0 if you do not want retries to happen
-	RetryAttempts int
-	// PrintPayloadOnError is whether or not to output the payload to the set logger or to stderr if
-	// an error occurs during transport to the Rollbar API.
-	PrintPayloadOnError bool
-	httpClient          *http.Client
+	baseTransport
 }
 
 // NewSyncTransport builds a synchronous transport which sends data to the Rollbar API at the
 // specified endpoint using the given access token.
 func NewSyncTransport(token, endpoint string) *SyncTransport {
 	return &SyncTransport{
-		Token:               token,
-		Endpoint:            endpoint,
-		RetryAttempts:       DefaultRetryAttempts,
-		PrintPayloadOnError: true,
+		baseTransport{
+			Token:               token,
+			Endpoint:            endpoint,
+			RetryAttempts:       DefaultRetryAttempts,
+			PrintPayloadOnError: true,
+		},
 	}
 }
 
@@ -43,7 +28,7 @@ func (t *SyncTransport) Send(body map[string]interface{}) error {
 }
 
 func (t *SyncTransport) doSend(body map[string]interface{}, retriesLeft int) error {
-	err, canRetry := clientPost(t.Token, t.Endpoint, body, t.Logger, t.getHttpClient())
+	err, canRetry := t.post(body)
 	if err != nil {
 		if !canRetry || retriesLeft <= 0 {
 			if t.PrintPayloadOnError {
@@ -62,45 +47,4 @@ func (t *SyncTransport) Wait() {}
 // Close is a no-op for the synchronous transport.
 func (t *SyncTransport) Close() error {
 	return nil
-}
-
-// SetToken updates the token to use for future API requests.
-func (t *SyncTransport) SetToken(token string) {
-	t.Token = token
-}
-
-// SetEndpoint updates the API endpoint to send items to.
-func (t *SyncTransport) SetEndpoint(endpoint string) {
-	t.Endpoint = endpoint
-}
-
-// SetLogger updates the logger that this transport uses for reporting errors that occur while
-// processing items.
-func (t *SyncTransport) SetLogger(logger ClientLogger) {
-	t.Logger = logger
-}
-
-// SetRetryAttempts is how often to attempt to resend an item when a temporary network error occurs
-// This defaults to DefaultRetryAttempts
-// Set this value to 0 if you do not want retries to happen
-func (t *SyncTransport) SetRetryAttempts(retryAttempts int) {
-	t.RetryAttempts = retryAttempts
-}
-
-// SetPrintPayloadOnError is whether or not to output the payload to stderr if an error occurs during
-// transport to the Rollbar API.
-func (t *SyncTransport) SetPrintPayloadOnError(printPayloadOnError bool) {
-	t.PrintPayloadOnError = printPayloadOnError
-}
-
-func (t *SyncTransport) SetHttpClient(c *http.Client) {
-	t.httpClient = c
-}
-
-func (t *SyncTransport) getHttpClient() *http.Client {
-	if t.httpClient != nil {
-		return t.httpClient
-	}
-
-	return http.DefaultClient
 }

--- a/transport.go
+++ b/transport.go
@@ -39,7 +39,7 @@ type Transport interface {
 	// Set whether to print the payload to the set logger or to stderr upon failing to send.
 	SetPrintPayloadOnError(printPayloadOnError bool)
 	// Set custom http client instead of http.DefaultClient
-	SetHttpClient(httpClient *http.Client)
+	SetHTTPClient(httpClient *http.Client)
 }
 
 // ClientLogger is the interface used by the rollbar Client/Transport to report problems.

--- a/transport.go
+++ b/transport.go
@@ -38,7 +38,7 @@ type Transport interface {
 	SetRetryAttempts(retryAttempts int)
 	// Set whether to print the payload to the set logger or to stderr upon failing to send.
 	SetPrintPayloadOnError(printPayloadOnError bool)
-	// Set custom http client instead of http.DefaultClient
+	// Sets custom http client. http.DefaultClient is used by default
 	SetHTTPClient(httpClient *http.Client)
 }
 

--- a/transport.go
+++ b/transport.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 )
 
@@ -37,6 +38,8 @@ type Transport interface {
 	SetRetryAttempts(retryAttempts int)
 	// Set whether to print the payload to the set logger or to stderr upon failing to send.
 	SetPrintPayloadOnError(printPayloadOnError bool)
+	// Set custom http client instead of http.DefaultClient
+	SetHttpClient(httpClient *http.Client)
 }
 
 // ClientLogger is the interface used by the rollbar Client/Transport to report problems.


### PR DESCRIPTION
Hello.

I wish there could be a way to set custom http client. Currently the only way to change http settings is either to change `http.DefaultClient` or to re-implement transport's `Send` method. Neither is handy. If you're ok with general direction will add specs and doc comments. Thanks.