### PR TITLE
Build diagnostic.configuredOptions per payload, not in singleton client

### DIFF
--- a/client.go
+++ b/client.go
@@ -76,39 +76,33 @@ func (c *Client) SetToken(token string) {
 
 // SetEnvironment sets the environment under which all errors and messages will be submitted.
 func (c *Client) SetEnvironment(environment string) {
-	c.diagnostic.configuredOptions["environment"] = environment
 	c.configuration.environment = environment
 }
 
 // SetEndpoint sets the endpoint to post items to. This also configures the underlying Transport.
 func (c *Client) SetEndpoint(endpoint string) {
-	c.diagnostic.configuredOptions["endpoint"] = endpoint
 	c.configuration.endpoint = endpoint
 	c.Transport.SetEndpoint(endpoint)
 }
 
 // SetPlatform sets the platform to be reported for all items.
 func (c *Client) SetPlatform(platform string) {
-	c.diagnostic.configuredOptions["platform"] = platform
 	c.configuration.platform = platform
 }
 
 // SetCodeVersion sets the string describing the running code version on the server.
 func (c *Client) SetCodeVersion(codeVersion string) {
-	c.diagnostic.configuredOptions["codeVersion"] = codeVersion
 	c.configuration.codeVersion = codeVersion
 }
 
 // SetServerHost sets the hostname sent with each item. This value will be indexed.
 func (c *Client) SetServerHost(serverHost string) {
-	c.diagnostic.configuredOptions["serverHost"] = serverHost
 	c.configuration.serverHost = serverHost
 }
 
 // SetServerRoot sets the path to the application code root, not including the final slash.
 // This is used to collapse non-project code when displaying tracebacks.
 func (c *Client) SetServerRoot(serverRoot string) {
-	c.diagnostic.configuredOptions["serverRoot"] = serverRoot
 	c.configuration.serverRoot = serverRoot
 }
 
@@ -127,11 +121,6 @@ func (c *Client) SetPerson(id, username, email string) {
 		Email:    email,
 	}
 
-	c.diagnostic.configuredOptions["person"] = map[string]string{
-		"Id":       id,
-		"Username": username,
-		"Email":    email,
-	}
 	c.configuration.person = person
 }
 
@@ -140,14 +129,12 @@ func (c *Client) SetPerson(id, username, email string) {
 func (c *Client) ClearPerson() {
 	person := Person{}
 
-	c.diagnostic.configuredOptions["person"] = map[string]string{}
 	c.configuration.person = person
 }
 
 // SetFingerprint sets whether or not to use a custom client-side fingerprint. The default value is
 // false.
 func (c *Client) SetFingerprint(fingerprint bool) {
-	c.diagnostic.configuredOptions["fingerprint"] = fingerprint
 	c.configuration.fingerprint = fingerprint
 }
 
@@ -159,14 +146,12 @@ func (c *Client) SetLogger(logger ClientLogger) {
 // SetScrubHeaders sets the regular expression used to match headers for scrubbing.
 // The default value is regexp.MustCompile("Authorization")
 func (c *Client) SetScrubHeaders(headers *regexp.Regexp) {
-	c.diagnostic.configuredOptions["scrubHeaders"] = headers
 	c.configuration.scrubHeaders = headers
 }
 
 // SetScrubFields sets the regular expression to match keys in the item payload for scrubbing.
 // The default vlaue is regexp.MustCompile("password|secret|token"),
 func (c *Client) SetScrubFields(fields *regexp.Regexp) {
-	c.diagnostic.configuredOptions["scrubFields"] = fields
 	c.configuration.scrubFields = fields
 }
 
@@ -182,7 +167,6 @@ func (c *Client) SetScrubFields(fields *regexp.Regexp) {
 // make before it is finally sent. Be careful with the modifications you make as they could lead to
 // the payload being malformed from the perspective of the API.
 func (c *Client) SetTransform(transform func(map[string]interface{})) {
-	c.diagnostic.configuredOptions["transform"] = functionToString(transform)
 	c.configuration.transform = transform
 }
 
@@ -194,7 +178,6 @@ func (c *Client) SetTransform(transform func(map[string]interface{})) {
 // In order to preserve the default unwrapping behavior, callers of SetUnwrapper may wish to include
 // a call to DefaultUnwrapper in their custom unwrapper function. See the example on the SetUnwrapper function.
 func (c *Client) SetUnwrapper(unwrapper UnwrapperFunc) {
-	c.diagnostic.configuredOptions["unwrapper"] = functionToString(unwrapper)
 	c.configuration.unwrapper = unwrapper
 }
 
@@ -207,7 +190,6 @@ func (c *Client) SetUnwrapper(unwrapper UnwrapperFunc) {
 // to include a call to DefaultStackTracer in their custom tracing function. See the example
 // on the SetStackTracer function.
 func (c *Client) SetStackTracer(stackTracer StackTracerFunc) {
-	c.diagnostic.configuredOptions["stackTracer"] = functionToString(stackTracer)
 	c.configuration.stackTracer = stackTracer
 }
 
@@ -218,7 +200,6 @@ func (c *Client) SetStackTracer(stackTracer StackTracerFunc) {
 // this function is called with the result of calling Error(), otherwise
 // the string representation of the value is passed to this function.
 func (c *Client) SetCheckIgnore(checkIgnore func(string) bool) {
-	c.diagnostic.configuredOptions["checkIgnore"] = functionToString(checkIgnore)
 	c.configuration.checkIgnore = checkIgnore
 }
 
@@ -227,7 +208,6 @@ func (c *Client) SetCheckIgnore(checkIgnore func(string) bool) {
 // CaptureIpAnonymize means apply a pseudo-anonymization.
 // CaptureIpNone means do not capture anything.
 func (c *Client) SetCaptureIp(captureIp captureIp) {
-	c.diagnostic.configuredOptions["captureIp"] = captureIp
 	c.configuration.captureIp = captureIp
 }
 
@@ -690,13 +670,11 @@ func createConfiguration(token, environment, codeVersion, serverHost, serverRoot
 
 type diagnostic struct {
 	languageVersion   string
-	configuredOptions map[string]interface{}
 }
 
 func createDiagnostic() diagnostic {
 	return diagnostic{
 		languageVersion:   runtime.Version(),
-		configuredOptions: map[string]interface{}{},
 	}
 }
 
@@ -729,8 +707,4 @@ func isTemporary(err error) bool {
 		return err.Timeout()
 	}
 	return false
-}
-
-func functionToString(function interface{}) string {
-	return runtime.FuncForPC(reflect.ValueOf(function).Pointer()).Name()
 }

--- a/transforms.go
+++ b/transforms.go
@@ -35,7 +35,7 @@ func buildBody(ctx context.Context, configuration configuration, diagnostic diag
 			"version": VERSION,
 			"diagnostic": map[string]interface{}{
 				"languageVersion": diagnostic.languageVersion,
-				"configuredOptions": diagnostic.configuredOptions,
+				"configuredOptions": buildConfiguredOptions(configuration),
 			},
 		},
 	}
@@ -75,6 +75,30 @@ func buildCustom(custom map[string]interface{}, extras map[string]interface{}) m
 		m[k] = v
 	}
 	return m
+}
+
+func buildConfiguredOptions(configuration configuration) map[string]interface{} {
+	return map[string]interface{}{
+		"environment":  configuration.environment,
+		"endpoint":     configuration.endpoint,
+		"platform":     configuration.platform,
+		"codeVersion":  configuration.codeVersion,
+		"serverHost":   configuration.serverHost,
+		"serverRoot":   configuration.serverRoot,
+		"fingerprint":  configuration.fingerprint,
+		"scrubHeaders": configuration.scrubHeaders,
+		"scrubFields":  configuration.scrubFields,
+		"transform":    functionToString(configuration.transform),
+		"unwrapper":    functionToString(configuration.unwrapper),
+		"stackTracer":  functionToString(configuration.stackTracer),
+		"checkIgnore":  functionToString(configuration.checkIgnore),
+		"captureIp":    configuration.captureIp,
+		"person": map[string]string{
+			"Id":       configuration.person.Id,
+			"Username": configuration.person.Username,
+			"Email":    configuration.person.Email,
+		},
+	}
 }
 
 func addErrorToBody(configuration configuration, body map[string]interface{}, err error, skip int) map[string]interface{} {
@@ -303,4 +327,8 @@ func errorClass(err error) string {
 	} else {
 		return strings.TrimPrefix(class, "*")
 	}
+}
+
+func functionToString(function interface{}) string {
+	return runtime.FuncForPC(reflect.ValueOf(function).Pointer()).Name()
 }


### PR DESCRIPTION
## Description of the change

This PR moves creation of the `diagnostic.configuredOptions` map into transforms.go where the payload is built.

The original issue reported a concurrent map writes error when calling `setPerson()` from multiple goroutines.

The solution I initially considered would wrap access to the `configuredOptions` map in a mutex. However it's required to also wrap read access, so unless transforms.go also had access to the mutex, the client should send a copy of the map to be included in the payload.

If a copy must be made anyway, it makes more sense to build `configuredOptions` in transforms.go when each payload is built. The code is simplified and the mutex is no longer needed.

The existing test that verify the correctness of the `configuredOptions` still pass and have not been modified for this PR.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

fixes ch74541

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
