### PR TITLE
added telemetry support

### DIFF
--- a/base_transport.go
+++ b/base_transport.go
@@ -68,7 +68,7 @@ func (t *baseTransport) getHTTPClient() *http.Client {
 		return t.httpClient
 	}
 
-	return &http.Client{}
+	return http.DefaultClient
 }
 
 // post returns an error which indicates the type of error that occurred while attempting to

--- a/base_transport.go
+++ b/base_transport.go
@@ -68,7 +68,7 @@ func (t *baseTransport) getHTTPClient() *http.Client {
 		return t.httpClient
 	}
 
-	return http.DefaultClient
+	return &http.Client{}
 }
 
 // post returns an error which indicates the type of error that occurred while attempting to

--- a/client.go
+++ b/client.go
@@ -42,7 +42,7 @@ func NewAsync(token, environment, codeVersion, serverHost, serverRoot string) *C
 	diagnostic := createDiagnostic()
 	return &Client{
 		Transport:     transport,
-		Telemetry:     NewTelemetry(),
+		Telemetry:     NewTelemetry(nil),
 		configuration: configuration,
 		diagnostic:    diagnostic,
 	}
@@ -55,7 +55,7 @@ func NewSync(token, environment, codeVersion, serverHost, serverRoot string) *Cl
 	diagnostic := createDiagnostic()
 	return &Client{
 		Transport:     transport,
-		Telemetry:     NewTelemetry(),
+		Telemetry:     NewTelemetry(nil),
 		configuration: configuration,
 		diagnostic:    diagnostic,
 	}
@@ -75,7 +75,7 @@ func (c *Client) CaptureTelemetryEvent(eventType, eventlevel string, eventData m
 
 // SetTelemetry sets the telemetry
 func (c *Client) SetTelemetry(options ...OptionFunc) {
-	c.Telemetry = NewTelemetry(options...)
+	c.Telemetry = NewTelemetry(c.configuration.scrubHeaders, options...)
 }
 
 // SetEnabled sets whether or not Rollbar is enabled.

--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"time"
 )
 
 // A Client can be used to interact with Rollbar via the configured Transport.
@@ -23,6 +24,7 @@ type Client struct {
 	// Transport used to send data to the Rollbar API. By default an asynchronous
 	// implementation of the Transport interface is used.
 	Transport     Transport
+	Telemetry     *Telemetry
 	configuration configuration
 	diagnostic    diagnostic
 }
@@ -40,6 +42,7 @@ func NewAsync(token, environment, codeVersion, serverHost, serverRoot string) *C
 	diagnostic := createDiagnostic()
 	return &Client{
 		Transport:     transport,
+		Telemetry:     NewTelemetry(),
 		configuration: configuration,
 		diagnostic:    diagnostic,
 	}
@@ -52,9 +55,27 @@ func NewSync(token, environment, codeVersion, serverHost, serverRoot string) *Cl
 	diagnostic := createDiagnostic()
 	return &Client{
 		Transport:     transport,
+		Telemetry:     NewTelemetry(),
 		configuration: configuration,
 		diagnostic:    diagnostic,
 	}
+}
+
+// CaptureTelemetryEvent sets the user-specified telemetry event
+func (c *Client) CaptureTelemetryEvent(eventType, eventlevel string, eventData map[string]interface{}) {
+	data := map[string]interface{}{}
+	data["body"] = eventData
+	data["type"] = eventType
+	data["level"] = eventlevel
+	data["source"] = "client"
+	data["timestamp_ms"] = time.Now().UnixNano() / int64(time.Millisecond)
+
+	c.Telemetry.Queue.Push(data)
+}
+
+// SetTelemetry sets the telemetry
+func (c *Client) SetTelemetry(t *Telemetry) {
+	c.Telemetry = t
 }
 
 // SetEnabled sets whether or not Rollbar is enabled.
@@ -361,7 +382,8 @@ func (c *Client) ErrorWithStackSkipWithExtrasAndContext(ctx context.Context, lev
 		return
 	}
 	body := c.buildBody(ctx, level, err.Error(), extras)
-	addErrorToBody(c.configuration, body, err, skip)
+	telemetry := c.Telemetry.GetQueueItems()
+	addErrorToBody(c.configuration, body, err, skip, telemetry)
 	c.push(body)
 }
 
@@ -389,7 +411,8 @@ func (c *Client) RequestErrorWithStackSkipWithExtrasAndContext(ctx context.Conte
 		return
 	}
 	body := c.buildBody(ctx, level, err.Error(), extras)
-	data := addErrorToBody(c.configuration, body, err, skip)
+	telemetry := c.Telemetry.GetQueueItems()
+	data := addErrorToBody(c.configuration, body, err, skip, telemetry)
 	data["request"] = c.requestDetails(r)
 	c.push(body)
 }
@@ -415,7 +438,10 @@ func (c *Client) MessageWithExtrasAndContext(ctx context.Context, level string, 
 	}
 	body := c.buildBody(ctx, level, msg, extras)
 	data := body["data"].(map[string]interface{})
-	data["body"] = messageBody(msg)
+	dataBody := messageBody(msg)
+	telemetry := c.Telemetry.GetQueueItems()
+	dataBody["telemetry"] = telemetry
+	data["body"] = dataBody
 	c.push(body)
 }
 
@@ -440,7 +466,10 @@ func (c *Client) RequestMessageWithExtrasAndContext(ctx context.Context, level s
 	}
 	body := c.buildBody(ctx, level, msg, extras)
 	data := body["data"].(map[string]interface{})
-	data["body"] = messageBody(msg)
+	dataBody := messageBody(msg)
+	telemetry := c.Telemetry.GetQueueItems()
+	dataBody["telemetry"] = telemetry
+	data["body"] = dataBody
 	data["request"] = c.requestDetails(r)
 	c.push(body)
 }
@@ -669,12 +698,12 @@ func createConfiguration(token, environment, codeVersion, serverHost, serverRoot
 }
 
 type diagnostic struct {
-	languageVersion   string
+	languageVersion string
 }
 
 func createDiagnostic() diagnostic {
 	return diagnostic{
-		languageVersion:   runtime.Version(),
+		languageVersion: runtime.Version(),
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -74,8 +74,8 @@ func (c *Client) CaptureTelemetryEvent(eventType, eventlevel string, eventData m
 }
 
 // SetTelemetry sets the telemetry
-func (c *Client) SetTelemetry(t *Telemetry) {
-	c.Telemetry = t
+func (c *Client) SetTelemetry(options ...OptionFunc) {
+	c.Telemetry = NewTelemetry(options...)
 }
 
 // SetEnabled sets whether or not Rollbar is enabled.
@@ -168,6 +168,7 @@ func (c *Client) SetLogger(logger ClientLogger) {
 // The default value is regexp.MustCompile("Authorization")
 func (c *Client) SetScrubHeaders(headers *regexp.Regexp) {
 	c.configuration.scrubHeaders = headers
+	c.Telemetry.Network.ScrubHeaders = headers
 }
 
 // SetScrubFields sets the regular expression to match keys in the item payload for scrubbing.

--- a/client_test.go
+++ b/client_test.go
@@ -436,7 +436,7 @@ func testGettersAndSetters(client *rollbar.Client, t *testing.T) {
 	errorIfEqual(fingerprint, client.Fingerprint(), t)
 	errorIfEqual(captureIP, client.CaptureIp(), t)
 	errorIfEqual(scrubHeaders, client.ScrubHeaders(), t)
-	errorIfNotEqual(scrubHeaders, client.Telemetry.Network.ScrubHeaders, t)
+	errorIfEqual(scrubHeaders, client.Telemetry.Network.ScrubHeaders, t)
 	errorIfEqual(scrubFields, client.ScrubFields(), t)
 
 	if client.Fingerprint() {

--- a/client_test.go
+++ b/client_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/rollbar/rollbar-go"
 	"net/http"
 	"reflect"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/rollbar/rollbar-go"
 )
 
 type TestTransport struct {
@@ -435,6 +436,7 @@ func testGettersAndSetters(client *rollbar.Client, t *testing.T) {
 	errorIfEqual(fingerprint, client.Fingerprint(), t)
 	errorIfEqual(captureIP, client.CaptureIp(), t)
 	errorIfEqual(scrubHeaders, client.ScrubHeaders(), t)
+	errorIfNotEqual(scrubHeaders, client.Telemetry.Network.ScrubHeaders, t)
 	errorIfEqual(scrubFields, client.ScrubFields(), t)
 
 	if client.Fingerprint() {
@@ -476,6 +478,7 @@ func testGettersAndSetters(client *rollbar.Client, t *testing.T) {
 	errorIfNotEqual(fingerprint, client.Fingerprint(), t)
 	errorIfNotEqual(captureIP, client.CaptureIp(), t)
 	errorIfNotEqual(scrubHeaders, client.ScrubHeaders(), t)
+	errorIfNotEqual(scrubHeaders, client.Telemetry.Network.ScrubHeaders, t)
 	errorIfNotEqual(scrubFields, client.ScrubFields(), t)
 
 	if !client.Fingerprint() {

--- a/client_test.go
+++ b/client_test.go
@@ -465,6 +465,7 @@ func testGettersAndSetters(client *rollbar.Client, t *testing.T) {
 	client.SetScrubHeaders(scrubHeaders)
 	client.SetScrubFields(scrubFields)
 	client.SetCaptureIp(captureIP)
+	client.SetTelemetry()
 
 	client.SetEnabled(true)
 
@@ -677,6 +678,23 @@ func TestEnabled(t *testing.T) {
 		}
 	} else {
 		t.Fail()
+	}
+}
+
+func TestCaptureTelemetryEvent(t *testing.T) {
+	client := testClient()
+	data := map[string]interface{}{"message": "some message"}
+	client.CaptureTelemetryEvent("eventType", "eventLevel", data)
+	items := client.Telemetry.GetQueueItems()
+	if len(items) < 1 {
+		t.Error("Queue should not be empty")
+	}
+	item := items[0].(map[string]interface{})
+	delete(item, "timestamp_ms")
+	expectedData := map[string]interface{}{"body": data, "type": "eventType", "level": "eventLevel", "source": "client"}
+	eq := reflect.DeepEqual(item, expectedData)
+	if !eq {
+		t.Error("Maps are different")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/rollbar/rollbar-go
 
 go 1.13
+
+require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/queue.go
+++ b/queue.go
@@ -1,0 +1,59 @@
+package rollbar
+
+import "sync"
+
+// NewQueue returns a new queue with the given initial size.
+func NewQueue(size int) *Queue {
+	return &Queue{
+		nodes: make([]interface{}, size),
+		size:  size,
+	}
+}
+
+// Queue is a basic FIFO queue based on a circular list that resizes as needed.
+type Queue struct {
+	nodes []interface{}
+	size  int
+	head  int
+	tail  int
+	count int
+
+	lock sync.RWMutex
+}
+
+// Push adds a node to the queue.
+func (q *Queue) Push(n interface{}) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	if q.head == q.tail && q.count > 0 {
+		nodes := make([]interface{}, len(q.nodes)+q.size)
+		copy(nodes, q.nodes[q.head:])
+		copy(nodes[len(q.nodes)-q.head:], q.nodes[:q.head])
+		q.head = 0
+		q.tail = len(q.nodes)
+		q.nodes = nodes
+	}
+	q.nodes[q.tail] = n
+	q.tail = (q.tail + 1) % len(q.nodes)
+	q.count++
+}
+
+// Pop removes and returns a node from the queue in first to last order.
+func (q *Queue) Pop() interface{} {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	if q.count == 0 {
+		return nil
+	}
+	node := q.nodes[q.head]
+	q.head = (q.head + 1) % len(q.nodes)
+	q.count--
+	return node
+}
+
+// Items returns all populated (non nil) items
+func (q *Queue) Items() []interface{} {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+	return q.nodes[:q.count]
+}

--- a/rollbar.go
+++ b/rollbar.go
@@ -90,6 +90,22 @@ var DefaultStackTracer StackTracerFunc = func(err error) ([]runtime.Frame, bool)
 	return nil, false
 }
 
+// GetTelemetryHTTPClientTransport enables a user to set Transport on http client:
+// example: client := &http.Client{Transport: rollbar.GetTelemetryHTTPClientTransport()}
+func GetTelemetryHTTPClientTransport() http.RoundTripper {
+	return std.Telemetry
+}
+
+// SetTelemetry sets the telemetry
+func SetTelemetry(t *Telemetry) {
+	std.SetTelemetry(t)
+}
+
+// CaptureTelemetryEvent sets the user-specified telemetry event
+func CaptureTelemetryEvent(eventType, eventlevel string, eventData map[string]interface{}) {
+	std.CaptureTelemetryEvent(eventType, eventlevel, eventData)
+}
+
 // SetEnabled sets whether or not the managed Client instance is enabled.
 // If this is true then this library works as normal.
 // If this is false then no calls will be made to the network.

--- a/rollbar.go
+++ b/rollbar.go
@@ -90,15 +90,15 @@ var DefaultStackTracer StackTracerFunc = func(err error) ([]runtime.Frame, bool)
 	return nil, false
 }
 
-// GetTelemetryHTTPClientTransport enables a user to set Transport on http client:
-// example: client := &http.Client{Transport: rollbar.GetTelemetryHTTPClientTransport()}
-func GetTelemetryHTTPClientTransport() http.RoundTripper {
-	return std.Telemetry
+// SetHTTPClientForTelemetry sets the http client for telemetry.
+// client is passed by the reference and it's sets the Transport on the client.
+func SetHTTPClientForTelemetry(httpClient *http.Client) {
+	httpClient.Transport = std.Telemetry
 }
 
 // SetTelemetry sets the telemetry
-func SetTelemetry(t *Telemetry) {
-	std.SetTelemetry(t)
+func SetTelemetry(options ...OptionFunc) {
+	std.SetTelemetry(options...)
 }
 
 // CaptureTelemetryEvent sets the user-specified telemetry event

--- a/rollbar.go
+++ b/rollbar.go
@@ -90,12 +90,6 @@ var DefaultStackTracer StackTracerFunc = func(err error) ([]runtime.Frame, bool)
 	return nil, false
 }
 
-// SetHTTPClientForTelemetry sets the http client for telemetry.
-// client is passed by the reference and it's sets the Transport on the client.
-func SetHTTPClientForTelemetry(httpClient *http.Client) {
-	httpClient.Transport = std.Telemetry
-}
-
 // SetTelemetry sets the telemetry
 func SetTelemetry(options ...OptionFunc) {
 	std.SetTelemetry(options...)

--- a/telemetry.go
+++ b/telemetry.go
@@ -22,9 +22,8 @@ type Telemetry struct {
 		Proxied      http.RoundTripper
 		ScrubHeaders *regexp.Regexp
 
-		enableDefaultClient bool
-		enableReqHeaders    bool
-		enableResHeaders    bool
+		enableReqHeaders bool
+		enableResHeaders bool
 	}
 	Queue *Queue
 }
@@ -82,7 +81,6 @@ func (t *Telemetry) populateTransporterBody(req *http.Request, res *http.Respons
 			response := map[string]interface{}{"headers": filteredDataHeaders}
 			dataBody["response"] = response
 		}
-
 	}
 	dataBody["url"] = req.URL.Scheme + "://" + req.Host + req.URL.Path
 	dataBody["method"] = req.Method
@@ -111,19 +109,13 @@ func (t *Telemetry) GetQueueItems() []interface{} {
 // OptionFunc is the pointer to the optional parameter function
 type OptionFunc func(*Telemetry)
 
-// EnableNetworkTelemetry enables the network telemetry.
+// EnableNetworkTelemetry enables the network telemetry
 // it wraps up the client for telemetry
+// http.DefaultClient can also be passed by the reference
 func EnableNetworkTelemetry(httpClient *http.Client) OptionFunc {
 	return func(f *Telemetry) {
 		f.Network.Proxied = httpClient.Transport
 		httpClient.Transport = f
-	}
-}
-
-// EnableNetworkTelemetryForDefaultClient sets the http.DefaultClient for telemetry
-func EnableNetworkTelemetryForDefaultClient() OptionFunc {
-	return func(f *Telemetry) {
-		f.Network.enableDefaultClient = true
 	}
 }
 
@@ -169,11 +161,6 @@ func NewTelemetry(options ...OptionFunc) *Telemetry {
 	if res.Network.ScrubHeaders == nil { // set/define only once
 		res.Network.ScrubHeaders = regexp.MustCompile("Authorization")
 	}
-	if res.Network.enableDefaultClient {
-		if res.Network.Proxied == nil {
-			res.Network.Proxied = http.DefaultTransport
-		}
-		http.DefaultClient.Transport = res
-	}
+
 	return res
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -152,8 +152,8 @@ func EnableLoggerTelemetry() OptionFunc {
 	}
 }
 
-// NewTelemetry initializes telemetry object
-func NewTelemetry(options ...OptionFunc) *Telemetry {
+// NewTelemetry initializes telemetry object with scrubheader
+func NewTelemetry(scrubHeaders *regexp.Regexp, options ...OptionFunc) *Telemetry {
 	res := &Telemetry{
 		Queue: NewQueue(TelemetryQueueSize),
 	}
@@ -162,8 +162,10 @@ func NewTelemetry(options ...OptionFunc) *Telemetry {
 		opt(res)
 	}
 
-	if res.Network.ScrubHeaders == nil { // set/define only once
+	if scrubHeaders == nil {
 		res.Network.ScrubHeaders = regexp.MustCompile("Authorization")
+	} else {
+		res.Network.ScrubHeaders = scrubHeaders
 	}
 
 	return res

--- a/telemetry.go
+++ b/telemetry.go
@@ -1,0 +1,116 @@
+package rollbar
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Telemetry struct contains writer (for logs) and round tripper (for http client) and enables to queue the events
+type Telemetry struct {
+	Writer  io.Writer
+	Proxied http.RoundTripper
+	Queue   *Queue
+}
+
+// Write is the writer for telemetry logs
+func (t *Telemetry) Write(p []byte) (int, error) {
+	telemetryData := t.populateLoggerBody(p)
+	t.Queue.Push(telemetryData)
+	return t.Writer.Write(p)
+}
+
+// RoundTrip implements RoundTrip in http.RoundTripper
+func (t *Telemetry) RoundTrip(req *http.Request) (res *http.Response, e error) {
+
+	// Send the request, get the response (or the error)
+	res, e = t.Proxied.RoundTrip(req)
+	if e != nil {
+		fmt.Printf("Error: %v", e)
+	}
+	telemetryData := t.populateTransporterBody(req, res)
+	t.Queue.Push(telemetryData)
+	return
+}
+
+func (t *Telemetry) populateLoggerBody(p []byte) map[string]interface{} {
+	var data = map[string]interface{}{}
+	message := map[string]interface{}{"message": string(p)}
+	data["body"] = message
+	data["source"] = "client"
+	data["timestamp_ms"] = time.Now().UnixNano() / int64(time.Millisecond)
+	data["type"] = "log"
+	data["level"] = "log"
+	return data
+}
+
+func (t *Telemetry) populateTransporterBody(req *http.Request, res *http.Response) map[string]interface{} {
+	var data = map[string]interface{}{}
+	var dataBody = map[string]interface{}{}
+	var dataHeaders = map[string][]string{}
+	dataBody["status_code"] = nil
+	data["level"] = "info"
+	if res != nil {
+		dataBody["status_code"] = res.StatusCode
+		if res.StatusCode >= http.StatusInternalServerError {
+			data["level"] = "critical"
+		} else if res.StatusCode >= http.StatusBadRequest {
+			data["level"] = "error"
+		}
+	}
+	dataBody["url"] = req.URL.Scheme + "://" + req.Host + req.URL.Path
+	dataBody["method"] = req.Method
+	dataBody["subtype"] = "http"
+
+	for k, v := range req.Header {
+		dataHeaders[k] = v
+	}
+	dataBody["request_headers"] = dataHeaders
+
+	data["body"] = dataBody
+	data["source"] = "client"
+	data["timestamp_ms"] = time.Now().UnixNano() / int64(time.Millisecond)
+	data["type"] = "network"
+	return data
+}
+
+// GetQueueItems gets all the items from the queue
+func (t *Telemetry) GetQueueItems() []interface{} {
+	return t.Queue.Items()
+}
+
+// OptionFunc is the pointer to the optional parameter function
+type OptionFunc func(*Telemetry)
+
+// WithCustomTransporter sets the custom transporter
+func WithCustomTransporter(t http.RoundTripper) OptionFunc {
+	return func(f *Telemetry) {
+		f.Proxied = t
+	}
+}
+
+// WithCustomQueueSize initializes the queue with a custom size
+func WithCustomQueueSize(size int) OptionFunc {
+	return func(f *Telemetry) {
+		f.Queue = NewQueue(size)
+	}
+}
+
+// NewTelemetry initializes telemetry object
+func NewTelemetry(options ...OptionFunc) *Telemetry {
+	res := &Telemetry{
+		Proxied: http.DefaultTransport,
+		Queue:   NewQueue(50),
+		Writer:  os.Stdout,
+	}
+	for _, opt := range options {
+		opt(res)
+	}
+
+	log.SetOutput(res)
+	http.DefaultClient = &http.Client{Transport: res}
+	return res
+}

--- a/telemetry.go
+++ b/telemetry.go
@@ -114,7 +114,11 @@ type OptionFunc func(*Telemetry)
 // http.DefaultClient can also be passed by the reference
 func EnableNetworkTelemetry(httpClient *http.Client) OptionFunc {
 	return func(f *Telemetry) {
-		f.Network.Proxied = httpClient.Transport
+		if httpClient.Transport == nil {
+			f.Network.Proxied = http.DefaultTransport
+		} else {
+			f.Network.Proxied = httpClient.Transport
+		}
 		httpClient.Transport = f
 	}
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -22,7 +22,7 @@ type Telemetry struct {
 		Proxied      http.RoundTripper
 		ScrubHeaders *regexp.Regexp
 
-		enbaleDefaultClient bool
+		enableDefaultClient bool
 		disableReqHeaders   bool
 		disableResHeaders   bool
 	}
@@ -125,7 +125,7 @@ func EnableNetworkTelemetry(t http.RoundTripper) OptionFunc {
 // EnableNetworkTelemetryForDefaultClient sets the http.DefaultClient for telemetry
 func EnableNetworkTelemetryForDefaultClient() OptionFunc {
 	return func(f *Telemetry) {
-		f.Network.enbaleDefaultClient = true
+		f.Network.enableDefaultClient = true
 	}
 }
 
@@ -171,7 +171,7 @@ func NewTelemetry(options ...OptionFunc) *Telemetry {
 	if res.Network.ScrubHeaders == nil { // set/define only once
 		res.Network.ScrubHeaders = regexp.MustCompile("Authorization")
 	}
-	if res.Network.enbaleDefaultClient {
+	if res.Network.enableDefaultClient {
 		http.DefaultClient.Transport = res
 	}
 	return res

--- a/telemetry.go
+++ b/telemetry.go
@@ -6,28 +6,41 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 	"time"
 )
 
+const TelemetryQueueSize = 50
+
 // Telemetry struct contains writer (for logs) and round tripper (for http client) and enables to queue the events
 type Telemetry struct {
-	Writer  io.Writer
-	Proxied http.RoundTripper
-	Queue   *Queue
+	Logger struct {
+		Writer io.Writer
+	}
+
+	Network struct {
+		Proxied      http.RoundTripper
+		ScrubHeaders *regexp.Regexp
+
+		enbaleDefaultClient bool
+		disableReqHeaders   bool
+		disableResHeaders   bool
+	}
+	Queue *Queue
 }
 
 // Write is the writer for telemetry logs
 func (t *Telemetry) Write(p []byte) (int, error) {
 	telemetryData := t.populateLoggerBody(p)
 	t.Queue.Push(telemetryData)
-	return t.Writer.Write(p)
+	return t.Logger.Writer.Write(p)
 }
 
 // RoundTrip implements RoundTrip in http.RoundTripper
 func (t *Telemetry) RoundTrip(req *http.Request) (res *http.Response, e error) {
 
 	// Send the request, get the response (or the error)
-	res, e = t.Proxied.RoundTrip(req)
+	res, e = t.Network.Proxied.RoundTrip(req)
 	if e != nil {
 		fmt.Printf("Error: %v", e)
 	}
@@ -50,7 +63,6 @@ func (t *Telemetry) populateLoggerBody(p []byte) map[string]interface{} {
 func (t *Telemetry) populateTransporterBody(req *http.Request, res *http.Response) map[string]interface{} {
 	var data = map[string]interface{}{}
 	var dataBody = map[string]interface{}{}
-	var dataHeaders = map[string][]string{}
 	dataBody["status_code"] = nil
 	data["level"] = "info"
 	if res != nil {
@@ -60,16 +72,30 @@ func (t *Telemetry) populateTransporterBody(req *http.Request, res *http.Respons
 		} else if res.StatusCode >= http.StatusBadRequest {
 			data["level"] = "error"
 		}
+
+		if !t.Network.disableResHeaders {
+			var dataHeaders = map[string][]string{}
+			for k, v := range res.Header {
+				dataHeaders[k] = v
+			}
+			filteredDataHeaders := filterFlatten(t.Network.ScrubHeaders, dataHeaders, nil)
+			response := map[string]interface{}{"headers": filteredDataHeaders}
+			dataBody["response"] = response
+		}
+
 	}
 	dataBody["url"] = req.URL.Scheme + "://" + req.Host + req.URL.Path
 	dataBody["method"] = req.Method
 	dataBody["subtype"] = "http"
 
-	for k, v := range req.Header {
-		dataHeaders[k] = v
+	if !t.Network.disableReqHeaders {
+		var dataHeaders = map[string][]string{}
+		for k, v := range req.Header {
+			dataHeaders[k] = v
+		}
+		filteredDataHeaders := filterFlatten(t.Network.ScrubHeaders, dataHeaders, nil)
+		dataBody["request_headers"] = filteredDataHeaders
 	}
-	dataBody["request_headers"] = dataHeaders
-
 	data["body"] = dataBody
 	data["source"] = "client"
 	data["timestamp_ms"] = time.Now().UnixNano() / int64(time.Millisecond)
@@ -85,32 +111,67 @@ func (t *Telemetry) GetQueueItems() []interface{} {
 // OptionFunc is the pointer to the optional parameter function
 type OptionFunc func(*Telemetry)
 
-// WithCustomTransporter sets the custom transporter
-func WithCustomTransporter(t http.RoundTripper) OptionFunc {
+// EnableNetworkTelemetry enables the network telemetry.
+// if no custom http Transport is needed, then nil can be passed
+func EnableNetworkTelemetry(t http.RoundTripper) OptionFunc {
 	return func(f *Telemetry) {
-		f.Proxied = t
+		f.Network.Proxied = http.DefaultTransport
+		if t != nil {
+			f.Network.Proxied = t
+		}
 	}
 }
 
-// WithCustomQueueSize initializes the queue with a custom size
-func WithCustomQueueSize(size int) OptionFunc {
+// EnableNetworkTelemetryForDefaultClient sets the http.DefaultClient for telemetry
+func EnableNetworkTelemetryForDefaultClient() OptionFunc {
+	return func(f *Telemetry) {
+		f.Network.enbaleDefaultClient = true
+	}
+}
+
+// DisableNetworkTelemetryRequestHeaders disables telemetry request headers
+func DisableNetworkTelemetryRequestHeaders() OptionFunc {
+	return func(f *Telemetry) {
+		f.Network.disableReqHeaders = true
+	}
+}
+
+// DisableNetworkTelemetryResponseHeaders disables telemetry response headers
+func DisableNetworkTelemetryResponseHeaders() OptionFunc {
+	return func(f *Telemetry) {
+		f.Network.disableResHeaders = true
+	}
+}
+
+// SetCustomQueueSize initializes the queue with a custom size
+func SetCustomQueueSize(size int) OptionFunc {
 	return func(f *Telemetry) {
 		f.Queue = NewQueue(size)
+	}
+}
+
+// EnableLoggerTelemetry enables logger telemetry
+func EnableLoggerTelemetry() OptionFunc {
+	return func(f *Telemetry) {
+		f.Logger.Writer = os.Stdout
+		log.SetOutput(f)
 	}
 }
 
 // NewTelemetry initializes telemetry object
 func NewTelemetry(options ...OptionFunc) *Telemetry {
 	res := &Telemetry{
-		Proxied: http.DefaultTransport,
-		Queue:   NewQueue(50),
-		Writer:  os.Stdout,
+		Queue: NewQueue(TelemetryQueueSize),
 	}
+
 	for _, opt := range options {
 		opt(res)
 	}
-
-	log.SetOutput(res)
-	http.DefaultClient = &http.Client{Transport: res}
+	if res.Network.enbaleDefaultClient {
+		http.DefaultClient.Transport = res
+	}
+	if res.Network.ScrubHeaders == nil { // set/define only once
+		res.Network.ScrubHeaders = regexp.MustCompile("Authorization")
+	}
 	return res
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -167,11 +167,12 @@ func NewTelemetry(options ...OptionFunc) *Telemetry {
 	for _, opt := range options {
 		opt(res)
 	}
-	if res.Network.enbaleDefaultClient {
-		http.DefaultClient.Transport = res
-	}
+
 	if res.Network.ScrubHeaders == nil { // set/define only once
 		res.Network.ScrubHeaders = regexp.MustCompile("Authorization")
+	}
+	if res.Network.enbaleDefaultClient {
+		http.DefaultClient.Transport = res
 	}
 	return res
 }

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNewTelemetryDefault(t *testing.T) {
-	telemetry := NewTelemetry()
+	telemetry := NewTelemetry(nil)
 	assert.NotNil(t, telemetry)
 	expectedTelemetry := &Telemetry{Queue: NewQueue(TelemetryQueueSize)}
 	expectedTelemetry.Network.ScrubHeaders = regexp.MustCompile("Authorization")
@@ -25,7 +25,7 @@ func TestNewTelemetryDefault(t *testing.T) {
 
 func TestNewTelemetryWithOptions(t *testing.T) {
 	client := http.Client{}
-	telemetry := NewTelemetry(SetCustomQueueSize(100), EnableNetworkTelemetry(&client),
+	telemetry := NewTelemetry(nil, SetCustomQueueSize(100), EnableNetworkTelemetry(&client),
 		EnableNetworkTelemetryRequestHeaders(), EnableNetworkTelemetryResponseHeaders(), EnableLoggerTelemetry())
 	expectedTelemetry := &Telemetry{Queue: telemetry.Queue}
 	expectedTelemetry.Network.ScrubHeaders = regexp.MustCompile("Authorization")
@@ -42,7 +42,7 @@ func TestPopulateBody(t *testing.T) {
 	req.Header.Set("Some_name", "some_value")
 	rec := httptest.NewRecorder()
 
-	telemetry := NewTelemetry()
+	telemetry := NewTelemetry(nil)
 	EnableNetworkTelemetryRequestHeaders()(telemetry)
 	EnableNetworkTelemetryResponseHeaders()(telemetry)
 	data := telemetry.populateTransporterBody(req, rec.Result())
@@ -62,7 +62,7 @@ func TestPopulateBody(t *testing.T) {
 func TestPopulateLoggerBody(t *testing.T) {
 
 	message := "some message"
-	telemetry := NewTelemetry()
+	telemetry := NewTelemetry(nil)
 
 	data := telemetry.populateLoggerBody([]byte(message))
 
@@ -86,7 +86,7 @@ func TestRoundTrip(t *testing.T) {
 	defer ts.Close()
 
 	client := http.Client{}
-	telemetry := NewTelemetry(EnableNetworkTelemetry(&client))
+	telemetry := NewTelemetry(nil, EnableNetworkTelemetry(&client))
 
 	req := httptest.NewRequest("GET", ts.URL+"/good", nil)
 	res, err := telemetry.RoundTrip(req)

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -1,0 +1,106 @@
+package rollbar
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTelemetryDefault(t *testing.T) {
+	telemetry := NewTelemetry()
+	assert.NotNil(t, telemetry)
+	expectedTelemetry := &Telemetry{Queue: NewQueue(TelemetryQueueSize)}
+	expectedTelemetry.Network.ScrubHeaders = regexp.MustCompile("Authorization")
+
+	assert.Equal(t, expectedTelemetry, telemetry)
+
+}
+
+func TestNewTelemetryWithOptions(t *testing.T) {
+	client := http.Client{}
+	telemetry := NewTelemetry(SetCustomQueueSize(100), EnableNetworkTelemetry(&client),
+		EnableNetworkTelemetryRequestHeaders(), EnableNetworkTelemetryResponseHeaders(), EnableLoggerTelemetry())
+	expectedTelemetry := &Telemetry{Queue: telemetry.Queue}
+	expectedTelemetry.Network.ScrubHeaders = regexp.MustCompile("Authorization")
+	expectedTelemetry.Network.enableReqHeaders = true
+	expectedTelemetry.Network.enableResHeaders = true
+	expectedTelemetry.Network.Proxied = http.DefaultTransport
+	expectedTelemetry.Logger.Writer = os.Stdout
+
+	assert.Equal(t, expectedTelemetry, telemetry)
+	assert.Equal(t, client.Transport, expectedTelemetry)
+}
+func TestPopulateBody(t *testing.T) {
+	req := httptest.NewRequest("GET", "/some_url", nil)
+	req.Header.Set("Some_name", "some_value")
+	rec := httptest.NewRecorder()
+
+	telemetry := NewTelemetry()
+	EnableNetworkTelemetryRequestHeaders()(telemetry)
+	EnableNetworkTelemetryResponseHeaders()(telemetry)
+	data := telemetry.populateTransporterBody(req, rec.Result())
+	assert.NotNil(t, data)
+	assert.True(t, data["timestamp_ms"].(int64) > 0)
+	delete(data, "timestamp_ms")
+
+	expectedBodyData := map[string]interface{}{"method": "GET", "status_code": 200, "subtype": "http",
+		"url": "://example.com/some_url", "request_headers": map[string]interface{}{"Some_name": "some_value"},
+		"response": map[string]interface{}{"headers": map[string]interface{}{}}}
+
+	expectedData := map[string]interface{}{"body": expectedBodyData, "level": "info", "source": "client", "type": "network"}
+
+	assert.Equal(t, expectedData, data)
+}
+
+func TestPopulateLoggerBody(t *testing.T) {
+
+	message := "some message"
+	telemetry := NewTelemetry()
+
+	data := telemetry.populateLoggerBody([]byte(message))
+
+	assert.NotNil(t, data)
+	assert.True(t, data["timestamp_ms"].(int64) > 0)
+	delete(data, "timestamp_ms")
+	expectedData := map[string]interface{}{"body": map[string]interface{}{"message": message}, "level": "log",
+		"source": "client", "type": "log"}
+
+	assert.Equal(t, expectedData, data)
+}
+
+func TestRoundTrip(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Print(">request: ", r)
+		if r.URL.String() == "/good" {
+			fmt.Fprintln(w, "Hello, client")
+		}
+	}))
+	defer ts.Close()
+
+	client := http.Client{}
+	telemetry := NewTelemetry(EnableNetworkTelemetry(&client))
+
+	req := httptest.NewRequest("GET", ts.URL+"/good", nil)
+	res, err := telemetry.RoundTrip(req)
+	assert.Nil(t, err)
+	assert.NotNil(t, res)
+
+	body, err := ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, "Hello, client\n", string(body))
+
+	items := telemetry.GetQueueItems()
+	assert.NotNil(t, items)
+
+	item := items[0]
+	expectedData := telemetry.populateTransporterBody(req, res)
+	assert.Equal(t, item, expectedData)
+}

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -107,3 +107,22 @@ func TestRoundTrip(t *testing.T) {
 	delete(expectedData, "timestamp_ms")
 	assert.Equal(t, item, expectedData)
 }
+
+func TestWrite(t *testing.T) {
+	telemetry := NewTelemetry(nil, EnableLoggerTelemetry())
+	message := "some message"
+	count, err := telemetry.Write([]byte(message))
+
+	assert.Nil(t, err)
+	assert.Equal(t, count, len(message))
+
+	items := telemetry.GetQueueItems()
+	assert.NotNil(t, items)
+
+	item := items[0].(map[string]interface{})
+	delete(item, "timestamp_ms")
+
+	expectedData := telemetry.populateLoggerBody([]byte(message))
+	delete(expectedData, "timestamp_ms")
+	assert.Equal(t, item, expectedData)
+}

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -100,7 +100,10 @@ func TestRoundTrip(t *testing.T) {
 	items := telemetry.GetQueueItems()
 	assert.NotNil(t, items)
 
-	item := items[0]
+	item := items[0].(map[string]interface{})
+	delete(item, "timestamp_ms")
+
 	expectedData := telemetry.populateTransporterBody(req, res)
+	delete(expectedData, "timestamp_ms")
 	assert.Equal(t, item, expectedData)
 }

--- a/transforms.go
+++ b/transforms.go
@@ -34,7 +34,7 @@ func buildBody(ctx context.Context, configuration configuration, diagnostic diag
 			"name":    NAME,
 			"version": VERSION,
 			"diagnostic": map[string]interface{}{
-				"languageVersion": diagnostic.languageVersion,
+				"languageVersion":   diagnostic.languageVersion,
 				"configuredOptions": buildConfiguredOptions(configuration),
 			},
 		},
@@ -101,10 +101,12 @@ func buildConfiguredOptions(configuration configuration) map[string]interface{} 
 	}
 }
 
-func addErrorToBody(configuration configuration, body map[string]interface{}, err error, skip int) map[string]interface{} {
+func addErrorToBody(configuration configuration, body map[string]interface{}, err error, skip int, telemetry []interface{}) map[string]interface{} {
 	data := body["data"].(map[string]interface{})
 	errBody, fingerprint := errorBody(configuration, err, skip)
-	data["body"] = errBody
+	dataBody := errBody
+	dataBody["telemetry"] = telemetry
+	data["body"] = dataBody
 	if configuration.fingerprint {
 		data["fingerprint"] = fingerprint
 	}


### PR DESCRIPTION
## Description of the change

- Added telemetry support 
- To initialize Telemetry with different options, a user can set it as following: 
```go
client := &http.Client{}
rollbar.SetTelemetry(rollbar.EnableNetworkTelemetry(client), rollbar.EnableLoggerTelemetry(),
	        rollbar.EnableNetworkTelemetryRequestHeaders(),
		rollbar.SetCustomQueueSize(100),
	)
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#82032](https://app.clubhouse.io/rollbar/story/82032/spike-go-telemetry-support) 
## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
