### PR TITLE
Add missing documentation on log context

### DIFF
--- a/rollbar.go
+++ b/rollbar.go
@@ -424,11 +424,13 @@ func Debug(interfaces ...interface{}) {
 //    string
 //    map[string]interface{}
 //    int
+//    context.Context
 // The string and error types are mutually exclusive.
 // If an error is present then a stack trace is captured. If an int is also present then we skip
 // that number of stack frames. If the map is present it is used as extra custom data in the
 // item. If a string is present without an error, then we log a message without a stack
-// trace. If a request is present we extract as much relevant information from it as we can.
+// trace. If a request is present we extract as much relevant information from it as we can. If
+// a context is present, it is applied to downstream operations.
 func Log(level string, interfaces ...interface{}) {
 	var r *http.Request
 	var err error


### PR DESCRIPTION
## Description of the change

Consumers of `Log` function can provide a `context.Context` ([source](https://github.com/rollbar/rollbar-go/blob/987360bc1bb5e6c6367df835b1cd492f96412beb/rollbar.go#L453)). The documentation somehow misses this fact. This PR fixes it.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
