### PR TITLE
added recovering in case of activity on a closed channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
           node-version: ${{ matrix.go-version }}
 
       - name: Run tests
-        run: go test
+        run: go test --race

--- a/async_transport_test.go
+++ b/async_transport_test.go
@@ -18,19 +18,18 @@ func TestAsyncTransportSend(t *testing.T) {
 }
 
 func TestAsyncTransportSendFull(t *testing.T) {
-	transport := NewAsyncTransport("", "", 1)
+	transport := NewAsyncTransport("", "", 0)
 	transport.SetLogger(&SilentClientLogger{})
 	body := map[string]interface{}{
 		"hello": "world",
 	}
 
-	transport.Send(body)
 	result := transport.Send(body)
 	if result == nil {
 		t.Error("Expected to receive ErrBufferFull")
 	}
 	transport.Wait()
-	if transport.perMinCounter != 1 {
+	if transport.perMinCounter != 0 {
 		t.Error("shouldSend check failed")
 	}
 }

--- a/async_transport_test.go
+++ b/async_transport_test.go
@@ -35,6 +35,18 @@ func TestAsyncTransportSendFull(t *testing.T) {
 	}
 }
 
+func TestAsyncTransportSendRecover(t *testing.T) {
+	transport := NewAsyncTransport("", "", 1)
+	transport.SetLogger(&SilentClientLogger{})
+
+	transport.Close()
+	result := transport.Send(nil)
+	if result == nil {
+		t.Error("Expected to receive ErrChannelClosed")
+	}
+	transport.Wait()
+}
+
 func TestAsyncTransportClose(t *testing.T) {
 	transport := NewAsyncTransport("", "", 1)
 	transport.SetLogger(&SilentClientLogger{})

--- a/errors.go
+++ b/errors.go
@@ -21,3 +21,12 @@ type ErrBufferFull struct{}
 func (e ErrBufferFull) Error() string {
 	return "buffer full, dropping error on the floor"
 }
+
+// ErrChannelClosed is an error which is returned when the asynchronous transport is used and the
+// channel used for buffering items for sending to Rollbar is already closed
+type ErrChannelClosed struct{}
+
+// Error implements the error interface.
+func (e ErrChannelClosed) Error() string {
+	return "channel is closed"
+}

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -133,6 +133,8 @@ func TestEverythingGeneric(t *testing.T) {
 		"hello": "rollbar",
 	})
 
+	SetItemsPerMinute(2000)
+	SetRetryAttempts(123)
 	SetLogger(&SilentClientLogger{})
 	Info(someNonstandardTypeForLogFailing{}, "I am a string and I did not fail")
 	SetLogger(nil)


### PR DESCRIPTION
## Description of the change
1. Gracefully recover when sending/receiving on the closed channel (protecting from panic)
issue# : #90 
3. Fixed race conditions (also protecting from possible panic)
## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #1

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
