### PR TITLE
added the function to disable default client

### DIFF
--- a/rollbar.go
+++ b/rollbar.go
@@ -95,6 +95,15 @@ func SetTelemetry(options ...OptionFunc) {
 	std.SetTelemetry(options...)
 }
 
+func DisableDefaultClient(destroy bool) {
+	if destroy {
+		std = nil
+		return
+	}
+	std.SetEnabled(false)
+	std.Close()
+}
+
 // CaptureTelemetryEvent sets the user-specified telemetry event
 func CaptureTelemetryEvent(eventType, eventlevel string, eventData map[string]interface{}) {
 	std.CaptureTelemetryEvent(eventType, eventlevel, eventData)

--- a/rollbar_closed_channel_test.go
+++ b/rollbar_closed_channel_test.go
@@ -1,0 +1,23 @@
+package rollbar
+
+import (
+	"testing"
+)
+
+func TestDisableDefaultClient(t *testing.T) {
+	defer func() {
+		std = NewAsync("", "development", "", hostname, "")
+
+	}()
+	DisableDefaultClient(false)
+	err := std.push(map[string]interface{}{
+		"data": map[string]interface{}{},
+	})
+	if err == nil {
+		t.Error("error should indicate that channel is closed")
+	}
+	DisableDefaultClient(true)
+	if std != nil {
+		t.Error("error should indicate that std is nil")
+	}
+}


### PR DESCRIPTION
## Description of the change

Disable the global default client by 2 ways:
1. set the client to nil (hard disable)
2. close the channel and set config enabled to false (soft disable)
## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #101

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
