### PR TITLE
remove mention of access_token in doc comment

### DIFF
--- a/client.go
+++ b/client.go
@@ -217,7 +217,6 @@ func (c *Client) SetScrubFields(fields *regexp.Regexp) {
 // is sent to the API.
 // The structure of the final payload sent to the API is:
 //   {
-//       "access_token": "YOUR_ACCESS_TOKEN",
 //       "data": { ... }
 //   }
 // This function takes a map[string]interface{} which is the value of the data key in the payload

--- a/rollbar.go
+++ b/rollbar.go
@@ -197,7 +197,6 @@ func SetScrubFields(fields *regexp.Regexp) {
 // is sent to the API.
 // The structure of the final payload sent to the API is:
 //   {
-//       "access_token": "YOUR_ACCESS_TOKEN",
 //       "data": { ... }
 //   }
 // This function takes a map[string]interface{} which is the value of the data key in the payload


### PR DESCRIPTION
## Description of the change

When logging errors to stderr is enabled, we print access tokens which is a security concern.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #1

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
