### PR TITLE
Export SetContext to support mocking Transport

### DIFF
--- a/async_transport.go
+++ b/async_transport.go
@@ -168,7 +168,7 @@ func (t *AsyncTransport) Close() error {
 	return nil
 }
 
-func (t *AsyncTransport) setContext(ctx context.Context) {
+func (t *AsyncTransport) SetContext(ctx context.Context) {
 	t.ctx = ctx
 }
 

--- a/client.go
+++ b/client.go
@@ -63,7 +63,7 @@ func NewAsync(token, environment, codeVersion, serverHost, serverRoot string, op
 	if c.ctx == nil {
 		c.ctx = context.Background()
 	}
-	c.Transport.setContext(c.ctx)
+	c.Transport.SetContext(c.ctx)
 	return c
 }
 
@@ -98,10 +98,10 @@ func (c *Client) SetTelemetry(options ...OptionFunc) {
 }
 func (c *Client) SetContext(ctx context.Context) {
 	c.ctx = ctx
-	c.Transport.setContext(ctx)
+	c.Transport.SetContext(ctx)
 }
 
-// SetEnabled sets whether or not Rollbar is enabled.
+// SetEnabled sets whether Rollbar is enabled.
 // If this is true then this library works as normal.
 // If this is false then no calls will be made to the network.
 // One place where this is useful is for turning off reporting in tests.

--- a/client_test.go
+++ b/client_test.go
@@ -23,7 +23,7 @@ func (t *TestTransport) Close() error {
 func (t *TestTransport) Wait() {
 	t.WaitCalled = true
 }
-func (t *TestTransport) setContext(ctx context.Context) {
+func (t *TestTransport) SetContext(ctx context.Context) {
 }
 
 func (t *TestTransport) SetToken(_t string)             {}

--- a/sync_transport.go
+++ b/sync_transport.go
@@ -65,5 +65,5 @@ func (t *SyncTransport) Wait() {}
 func (t *SyncTransport) Close() error {
 	return nil
 }
-func (t *SyncTransport) setContext(ctx context.Context) {
+func (t *SyncTransport) SetContext(ctx context.Context) {
 }

--- a/transport.go
+++ b/transport.go
@@ -23,7 +23,7 @@ type transportOption func(Transport)
 
 func WithTransportContext(ctx context.Context) transportOption {
 	return func(t Transport) {
-		t.setContext(ctx)
+		t.SetContext(ctx)
 	}
 }
 
@@ -51,8 +51,8 @@ type Transport interface {
 	SetHTTPClient(httpClient *http.Client)
 	// SetItemsPerMinute sets the max number of items to send in a given minute
 	SetItemsPerMinute(itemsPerMinute int)
-
-	setContext(ctx context.Context)
+	// SetContext sets the context to use for API calls made over the Transport
+	SetContext(ctx context.Context)
 }
 
 // ClientLogger is the interface used by the rollbar Client/Transport to report problems.


### PR DESCRIPTION
## Description of the change
Export the `setContext` method of the `Transport` interface to allow mocking via reimplmentation.

## Type of change
(I'm not sure how to categorize this change, if I'm honest - I'm selecting Maintenance)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)
- Fix #104 

## Checklists

### Development

- [ ] Lint rules pass locally (I was unable to determine what lint rules this might be referencing)
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
