### PR TITLE
Export SetContext to support mocking Transport

### DIFF
--- a/async_transport.go
+++ b/async_transport.go
@@ -168,7 +168,7 @@ func (t *AsyncTransport) Close() error {
 	return nil
 }
 
-func (t *AsyncTransport) setContext(ctx context.Context) {
+func (t *AsyncTransport) SetContext(ctx context.Context) {
 	t.ctx = ctx
 }
 

--- a/client.go
+++ b/client.go
@@ -63,7 +63,7 @@ func NewAsync(token, environment, codeVersion, serverHost, serverRoot string, op
 	if c.ctx == nil {
 		c.ctx = context.Background()
 	}
-	c.Transport.setContext(c.ctx)
+	c.Transport.SetContext(c.ctx)
 	return c
 }
 
@@ -98,7 +98,7 @@ func (c *Client) SetTelemetry(options ...OptionFunc) {
 }
 func (c *Client) SetContext(ctx context.Context) {
 	c.ctx = ctx
-	c.Transport.setContext(ctx)
+	c.Transport.SetContext(ctx)
 }
 
 // SetEnabled sets whether or not Rollbar is enabled.
@@ -216,10 +216,12 @@ func (c *Client) SetScrubFields(fields *regexp.Regexp) {
 // SetTransform sets the transform function called after the entire payload has been built before it
 // is sent to the API.
 // The structure of the final payload sent to the API is:
-//   {
-//       "access_token": "YOUR_ACCESS_TOKEN",
-//       "data": { ... }
-//   }
+//
+//	{
+//	    "access_token": "YOUR_ACCESS_TOKEN",
+//	    "data": { ... }
+//	}
+//
 // This function takes a map[string]interface{} which is the value of the data key in the payload
 // described above. You can modify this object in-place to make any arbitrary changes you wish to
 // make before it is finally sent. Be careful with the modifications you make as they could lead to

--- a/client_test.go
+++ b/client_test.go
@@ -23,7 +23,7 @@ func (t *TestTransport) Close() error {
 func (t *TestTransport) Wait() {
 	t.WaitCalled = true
 }
-func (t *TestTransport) setContext(ctx context.Context) {
+func (t *TestTransport) SetContext(ctx context.Context) {
 }
 
 func (t *TestTransport) SetToken(_t string)             {}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/rollbar/rollbar-go
 
 go 1.13
 
-require github.com/stretchr/testify v1.7.0
+require (
+	github.com/rollbar/rollbar-go/errors v1.0.0 // indirect
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rollbar/rollbar-go/errors v1.0.0 h1:8wgJym3dOpKeP85ZhQm2WfBwcAfUyXyYVYz2odY04G0=
+github.com/rollbar/rollbar-go/errors v1.0.0/go.mod h1:Ie0xEc1Cyj+T4XMO8s0Vf7pMfvSAAy1sb4AYc8aJsao=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/sync_transport.go
+++ b/sync_transport.go
@@ -65,5 +65,5 @@ func (t *SyncTransport) Wait() {}
 func (t *SyncTransport) Close() error {
 	return nil
 }
-func (t *SyncTransport) setContext(ctx context.Context) {
+func (t *SyncTransport) SetContext(ctx context.Context) {
 }

--- a/transport.go
+++ b/transport.go
@@ -23,7 +23,7 @@ type transportOption func(Transport)
 
 func WithTransportContext(ctx context.Context) transportOption {
 	return func(t Transport) {
-		t.setContext(ctx)
+		t.SetContext(ctx)
 	}
 }
 
@@ -51,8 +51,8 @@ type Transport interface {
 	SetHTTPClient(httpClient *http.Client)
 	// SetItemsPerMinute sets the max number of items to send in a given minute
 	SetItemsPerMinute(itemsPerMinute int)
-
-	setContext(ctx context.Context)
+	// SetContext sets the context to use for API calls made over the Transport
+	SetContext(ctx context.Context)
 }
 
 // ClientLogger is the interface used by the rollbar Client/Transport to report problems.


### PR DESCRIPTION
## Description of the change
Export the `setContext` method of the `Transport` interface to allow mocking via reimplmentation.

This build includes automatic and indirect reference of new package of rollbar-go/errors in the go.mod and go.sum files

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)
- Fix #104 

## Checklists

### Development

- [ ] Lint rules pass locally (I was unable to determine what lint rules this might be referencing)
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
